### PR TITLE
Fix the message in DriverInstallCommand

### DIFF
--- a/cli/bblfshctl/cmd/driver_install.go
+++ b/cli/bblfshctl/cmd/driver_install.go
@@ -81,7 +81,7 @@ func (c *DriverInstallCommand) Validate() error {
 }
 
 func (c *DriverInstallCommand) installDriver(lang, ref string) error {
-	fmt.Printf("Installing %s driver language from %q... ", lang, ref)
+	fmt.Printf("Installing %s language driver from %q... ", lang, ref)
 	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond) // Build our new spinner
 	s.Start()
 


### PR DESCRIPTION
Before: `Installing python driver language from "docker://bblfsh/python-driver:latest"`
After: ` Installing python language driver from "docker://bblfsh/python-driver:latest"`