### PR TITLE
Add SELinux policy file, hint in the typical panic caused by it and instructions in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,36 @@ and an example contained in the docker image:
 docker exec -it bblfshd bblfshctl parse /opt/bblfsh/etc/examples/python.py
 ```
 
+## SELinux
+
+If your system has SELinux enabled (is the default in Fedora, Red Hat, CentOS
+and many others) you need to compile and load a policy module before running the
+bblfshd Docker image or running driver containers will fail with a `permission
+denied` message in the logs. 
+
+To do this, run these commands from the project root:
+
+```bash
+cd selinux/
+sh compile.sh
+semodule -i bblfshd.pp
+```
+
+If you were already running an instance of bblfshd, you will need to delete the
+container (`docker rm -f bblfshd`) and run it again (`docker run...`).
+
+Once the module has been loaded with `semodule` the change should persist even
+if you reboot. If you want to permanently remove this module run `semodule -d bblfshd`.
+
+Alternatively, you could set SELinux to permissive module with:
+
+```
+echo 1 > /sys/fs/selinux/enforce
+```
+
+(doing this on production systems which usually have SELinux enabled by default
+should be strongly discouraged).
+
 ## Development
 
 If you wish to work on *bblfshd* , you'll first need [Go](http://www.golang.org)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -196,8 +196,8 @@ func Bootstrap() {
 		factory, _ := libcontainer.New("")
 		if err := factory.StartInitialization(); err != nil {
 			panic("error bootstraping container " +
-			      "(hint: if SELinux is enabled, compile and load the policy module " +
-				  "in the selinux/ directory in the bblfshd repo): " + err)
+				"(hint: if SELinux is enabled, compile and load the policy module " +
+				"in this repo's selinux/ directory): " + err)
 		}
 		panic("--this line should have never been executed, congratulations--")
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -195,7 +195,9 @@ func Bootstrap() {
 		runtime.LockOSThread()
 		factory, _ := libcontainer.New("")
 		if err := factory.StartInitialization(); err != nil {
-			panic(err)
+			panic("error bootstraping container " +
+			      "(hint: if SELinux is enabled, compile and load the policy module " +
+				  "in the selinux/ directory in the bblfshd repo): " + err)
 		}
 		panic("--this line should have never been executed, congratulations--")
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 
 	"github.com/opencontainers/runc/libcontainer"
@@ -195,9 +196,13 @@ func Bootstrap() {
 		runtime.LockOSThread()
 		factory, _ := libcontainer.New("")
 		if err := factory.StartInitialization(); err != nil {
-			panic("error bootstraping container " +
-				"(hint: if SELinux is enabled, compile and load the policy module " +
-				"in this repo's selinux/ directory): " + err)
+			if strings.Contains(err.Error(), "permission denied") {
+				panic("error bootstraping container " +
+					"(hint: if SELinux is enabled, compile and load the policy module " +
+					"in this repo's selinux/ directory): " + err.Error())
+			} else {
+				panic(err)
+			}
 		}
 		panic("--this line should have never been executed, congratulations--")
 	}

--- a/selinux/bblfshd.te
+++ b/selinux/bblfshd.te
@@ -1,0 +1,11 @@
+
+module bblfshd 1.0;
+
+require {
+        type container_runtime_t;
+        type spc_t;
+        class fifo_file setattr;
+}
+
+#============= spc_t ==============
+allow spc_t container_runtime_t:fifo_file setattr;

--- a/selinux/compile.sh
+++ b/selinux/compile.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+checkmodule -M -m -o bblfshd.mod bblfshd.te && \
+    semodule_package -o bblfshd.pp -m bblfshd.mod && \
+    echo 'Module compiled, load it with semodule -i bblfshd.pp'
+
+# enable with: semodule -i bblfshd.pp

--- a/selinux/compile.sh
+++ b/selinux/compile.sh
@@ -2,6 +2,4 @@
 
 checkmodule -M -m -o bblfshd.mod bblfshd.te && \
     semodule_package -o bblfshd.pp -m bblfshd.mod && \
-    echo 'Module compiled, load it with semodule -i bblfshd.pp'
-
-# enable with: semodule -i bblfshd.pp
+    echo 'Module compiled, load it with "semodule -i bblfshd.pp"'


### PR DESCRIPTION
Driver containers were failing to run on SELinux enabled systems. This PR adds:

- A SELinux policy module that enables the needed permission.
- A script to compile it.
- A SELinux section in the README with specific instructions.
- A hint message in the panic() caused by SELinux without the module.

I will also add some notes about this in the documentation once the PR has been merged.

Fixes #146.