### PR TITLE
move ostree dependency under build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ VERSION ?= $(DEV_PREFIX)-$(GIT_COMMIT)$(GIT_DIRTY)
 
 # Go parameters
 GO_CMD = go
-GO_BUILD = $(GO_CMD) build
+GO_BUILD = $(GO_CMD) build -tags ostree
 GO_CLEAN = $(GO_CMD) clean
 GO_GET = $(GO_CMD) get -v
 GO_TEST = $(GO_CMD) test -v

--- a/runtime/image_formats.go
+++ b/runtime/image_formats.go
@@ -1,0 +1,9 @@
+package runtime
+
+import (
+	_ "github.com/containers/image/directory"
+	_ "github.com/containers/image/docker"
+	_ "github.com/containers/image/docker/archive"
+	_ "github.com/containers/image/docker/daemon"
+	_ "github.com/containers/image/oci/layout"
+)

--- a/runtime/image_formats_ostree.go
+++ b/runtime/image_formats_ostree.go
@@ -1,0 +1,7 @@
+// +build ostree
+
+package runtime
+
+import (
+	_ "github.com/containers/image/ostree"
+)

--- a/runtime/parse_image_name.go
+++ b/runtime/parse_image_name.go
@@ -4,12 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	_ "github.com/containers/image/directory"
-	_ "github.com/containers/image/docker"
-	_ "github.com/containers/image/docker/archive"
-	_ "github.com/containers/image/docker/daemon"
-	_ "github.com/containers/image/oci/layout"
-	_ "github.com/containers/image/ostree"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"gopkg.in/src-d/go-errors.v1"


### PR DESCRIPTION
Currently bblfshd requires OSTree dependency that should be downloaded separately. To simplify local development this dependency is hidden under Go build tag. This allows to run 'go build' directly without downloading anything else.

Makefile will still build ostree by passing new build tag.

Signed-off-by: Denys Smirnov <denys@sourced.tech>