### PR TITLE
Fix make when run with no rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+all: clean test build
+
 # Docsrv: configure the languages whose api-doc can be auto generated
 LANGUAGES = "go"
 # Docs: do not edit this
@@ -90,8 +92,6 @@ DOCKER_IMAGE_VERSIONED ?= $(call escape_docker_tag,$(DOCKER_IMAGE):$(VERSION))
 DOCKER_IMAGE_FIXTURE ?= $(DOCKER_IMAGE):fixture
 
 # Rules
-all: clean test build
-
 dependencies: build-fixture
 
 #$(DEPENDENCIES):


### PR DESCRIPTION
bblfsh `README.md` recommends running `make` (with no rules) [for development](https://github.com/bblfsh/bblfshd/blame/master/README.md#L107).
To do so, `make::all` must be the first target but it is not because of the `-include docs/Makefile.inc`

An alternative could be to change the docs, and recommend `make all` or whatever other wording instead of a no-target make call.