### PR TITLE
bblfshd. Add SupportedLanguages method

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -538,8 +538,8 @@
     "uast",
     "uast/transformer"
   ]
-  revision = "9ec655062322ee4aaaac8c11c7660a7963905c1d"
-  version = "v1.13.0"
+  revision = "96e92bdde3785e655b8095a576addd52b96c6c61"
+  version = "v1.16.0"
 
 [[projects]]
   name = "gopkg.in/src-d/enry.v1"
@@ -571,6 +571,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a12b719cdb75efa7b884199aefbbbdb782238afa37b12ce11671bdb41cfbe785"
+  inputs-digest = "9b748bf13546a7c3a93dd660b5ca5b8deb1e347729fa45ef9d3c3eca4a7ae30b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,7 +43,7 @@
 
 [[constraint]]
   name = "gopkg.in/bblfsh/sdk.v1"
-  version = "1.13.0"
+  version = "1.16.0"
 
 [[constraint]]
   name = "gopkg.in/src-d/enry.v1"

--- a/daemon/common_test.go
+++ b/daemon/common_test.go
@@ -80,6 +80,12 @@ func (d *echoDriver) Version(
 	return &sdk.VersionResponse{}, nil
 }
 
+func (d *echoDriver) SupportedLanguages(
+	_ oldctx.Context, in *sdk.SupportedLanguagesRequest, opts ...grpc.CallOption) (*sdk.SupportedLanguagesResponse, error) {
+	drivers := []sdk.DriverManifest{sdk.DriverManifest{Name: "Python"}}
+	return &sdk.SupportedLanguagesResponse{Languages: drivers}, nil
+}
+
 func (d *echoDriver) Service() sdk.ProtocolServiceClient {
 	return d
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -10,12 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"gopkg.in/bblfsh/sdk.v1/protocol"
 
 	"github.com/bblfsh/bblfshd/runtime"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestDaemonState(t *testing.T) {
@@ -79,7 +78,7 @@ func TestDaemonParse_MockedDriverParallelClients(t *testing.T) {
 
 }
 
-func buildMockedDaemon(t *testing.T) (*Daemon, string) {
+func buildMockedDaemon(t *testing.T, images ...runtime.DriverImage) (*Daemon, string) {
 	require := require.New(t)
 
 	dir, err := ioutil.TempDir(os.TempDir(), "bblfsh-runtime")
@@ -88,6 +87,14 @@ func buildMockedDaemon(t *testing.T) (*Daemon, string) {
 	r := runtime.NewRuntime(dir)
 	err = r.Init()
 	require.NoError(err)
+
+	if images != nil {
+		for _, image := range images {
+			status, err := r.InstallDriver(image, false)
+			require.NotNil(status)
+			require.NoError(err)
+		}
+	}
 
 	d := NewDaemon("foo", r)
 

--- a/daemon/service_test.go
+++ b/daemon/service_test.go
@@ -71,3 +71,23 @@ func TestControlServiceDriverInstanceStates(t *testing.T) {
 	require.NoError(err)
 	require.Len(state, 1)
 }
+
+func TestService_SupportedLanguages(t *testing.T) {
+	require := require.New(t)
+
+	d, tmp := buildMockedDaemon(t, newMockDriverImage("language-1"), newMockDriverImage("language-2"))
+	defer os.RemoveAll(tmp)
+
+	s := NewService(d)
+	languages := s.SupportedLanguages(&protocol.SupportedLanguagesRequest{})
+	require.Len(languages.Errors, 0)
+	require.Len(languages.Languages, 2)
+
+	supportedLanguages := make([]string, 2)
+	for i, lang := range languages.Languages {
+		supportedLanguages[i] = lang.Name
+	}
+
+	require.Contains(supportedLanguages, "language-1")
+	require.Contains(supportedLanguages, "language-2")
+}

--- a/vendor/gopkg.in/bblfsh/sdk.v1/manifest/manifest.go
+++ b/vendor/gopkg.in/bblfsh/sdk.v1/manifest/manifest.go
@@ -81,7 +81,7 @@ const (
 func (os OS) AsImage() string {
 	switch os {
 	case Alpine:
-		return "alpine:3.6"
+		return "alpine:3.7"
 	case Debian:
 		return "debian:jessie-slim"
 	default:

--- a/vendor/gopkg.in/bblfsh/sdk.v1/protocol/generated.pb.go
+++ b/vendor/gopkg.in/bblfsh/sdk.v1/protocol/generated.pb.go
@@ -8,10 +8,13 @@
 		gopkg.in/bblfsh/sdk.v1/protocol/generated.proto
 
 	It has these top-level messages:
+		DriverManifest
 		NativeParseRequest
 		NativeParseResponse
 		ParseRequest
 		ParseResponse
+		SupportedLanguagesRequest
+		SupportedLanguagesResponse
 		VersionRequest
 		VersionResponse
 */
@@ -22,17 +25,15 @@ import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/protobuf/gogoproto"
 import _ "github.com/gogo/protobuf/types"
-import gopkg_in_bblfsh_sdk_v1_uast"gopkg.in/bblfsh/sdk.v1/uast"
+import gopkg_in_bblfsh_sdk_v1_uast "gopkg.in/bblfsh/sdk.v1/uast"
 import _ "github.com/gogo/protobuf/types"
 
 import time "time"
 
-import (
-	context "golang.org/x/net/context"
-	grpc "google.golang.org/grpc"
-)
+import context "golang.org/x/net/context"
+import grpc "google.golang.org/grpc"
 
-import github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
+import types "github.com/gogo/protobuf/types"
 
 import io "io"
 
@@ -76,39 +77,61 @@ var Status_value = map[string]int32{
 
 func (Status) EnumDescriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{1} }
 
+func (m *DriverManifest) Reset()                    { *m = DriverManifest{} }
+func (m *DriverManifest) String() string            { return proto.CompactTextString(m) }
+func (*DriverManifest) ProtoMessage()               {}
+func (*DriverManifest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{0} }
+
 func (m *NativeParseRequest) Reset()                    { *m = NativeParseRequest{} }
 func (m *NativeParseRequest) String() string            { return proto.CompactTextString(m) }
 func (*NativeParseRequest) ProtoMessage()               {}
-func (*NativeParseRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{0} }
+func (*NativeParseRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{1} }
 
 func (m *NativeParseResponse) Reset()                    { *m = NativeParseResponse{} }
 func (*NativeParseResponse) ProtoMessage()               {}
-func (*NativeParseResponse) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{1} }
+func (*NativeParseResponse) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{2} }
 
 func (m *ParseRequest) Reset()                    { *m = ParseRequest{} }
 func (m *ParseRequest) String() string            { return proto.CompactTextString(m) }
 func (*ParseRequest) ProtoMessage()               {}
-func (*ParseRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{2} }
+func (*ParseRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{3} }
 
 func (m *ParseResponse) Reset()                    { *m = ParseResponse{} }
 func (*ParseResponse) ProtoMessage()               {}
-func (*ParseResponse) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{3} }
+func (*ParseResponse) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{4} }
+
+func (m *SupportedLanguagesRequest) Reset()         { *m = SupportedLanguagesRequest{} }
+func (m *SupportedLanguagesRequest) String() string { return proto.CompactTextString(m) }
+func (*SupportedLanguagesRequest) ProtoMessage()    {}
+func (*SupportedLanguagesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptorGenerated, []int{5}
+}
+
+func (m *SupportedLanguagesResponse) Reset()         { *m = SupportedLanguagesResponse{} }
+func (m *SupportedLanguagesResponse) String() string { return proto.CompactTextString(m) }
+func (*SupportedLanguagesResponse) ProtoMessage()    {}
+func (*SupportedLanguagesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptorGenerated, []int{6}
+}
 
 func (m *VersionRequest) Reset()                    { *m = VersionRequest{} }
 func (m *VersionRequest) String() string            { return proto.CompactTextString(m) }
 func (*VersionRequest) ProtoMessage()               {}
-func (*VersionRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{4} }
+func (*VersionRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{7} }
 
 func (m *VersionResponse) Reset()                    { *m = VersionResponse{} }
 func (m *VersionResponse) String() string            { return proto.CompactTextString(m) }
 func (*VersionResponse) ProtoMessage()               {}
-func (*VersionResponse) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{5} }
+func (*VersionResponse) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{8} }
 
 func init() {
+	proto.RegisterType((*DriverManifest)(nil), "gopkg.in.bblfsh.sdk.v1.protocol.DriverManifest")
 	proto.RegisterType((*NativeParseRequest)(nil), "gopkg.in.bblfsh.sdk.v1.protocol.NativeParseRequest")
 	proto.RegisterType((*NativeParseResponse)(nil), "gopkg.in.bblfsh.sdk.v1.protocol.NativeParseResponse")
 	proto.RegisterType((*ParseRequest)(nil), "gopkg.in.bblfsh.sdk.v1.protocol.ParseRequest")
 	proto.RegisterType((*ParseResponse)(nil), "gopkg.in.bblfsh.sdk.v1.protocol.ParseResponse")
+	proto.RegisterType((*SupportedLanguagesRequest)(nil), "gopkg.in.bblfsh.sdk.v1.protocol.SupportedLanguagesRequest")
+	proto.RegisterType((*SupportedLanguagesResponse)(nil), "gopkg.in.bblfsh.sdk.v1.protocol.SupportedLanguagesResponse")
 	proto.RegisterType((*VersionRequest)(nil), "gopkg.in.bblfsh.sdk.v1.protocol.VersionRequest")
 	proto.RegisterType((*VersionResponse)(nil), "gopkg.in.bblfsh.sdk.v1.protocol.VersionResponse")
 	proto.RegisterEnum("gopkg.in.bblfsh.sdk.v1.protocol.Encoding", Encoding_name, Encoding_value)
@@ -131,6 +154,8 @@ type ProtocolServiceClient interface {
 	NativeParse(ctx context.Context, in *NativeParseRequest, opts ...grpc.CallOption) (*NativeParseResponse, error)
 	// Parse uses DefaultService to process the given parsing request to get the UAST.
 	Parse(ctx context.Context, in *ParseRequest, opts ...grpc.CallOption) (*ParseResponse, error)
+	// SupportedLanguages uses DefaultService to process the given SupportedLanguagesRequest to get the supported drivers.
+	SupportedLanguages(ctx context.Context, in *SupportedLanguagesRequest, opts ...grpc.CallOption) (*SupportedLanguagesResponse, error)
 	// Version uses DefaultVersioner to process the given version request to get the version.
 	Version(ctx context.Context, in *VersionRequest, opts ...grpc.CallOption) (*VersionResponse, error)
 }
@@ -161,6 +186,15 @@ func (c *protocolServiceClient) Parse(ctx context.Context, in *ParseRequest, opt
 	return out, nil
 }
 
+func (c *protocolServiceClient) SupportedLanguages(ctx context.Context, in *SupportedLanguagesRequest, opts ...grpc.CallOption) (*SupportedLanguagesResponse, error) {
+	out := new(SupportedLanguagesResponse)
+	err := grpc.Invoke(ctx, "/gopkg.in.bblfsh.sdk.v1.protocol.ProtocolService/SupportedLanguages", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *protocolServiceClient) Version(ctx context.Context, in *VersionRequest, opts ...grpc.CallOption) (*VersionResponse, error) {
 	out := new(VersionResponse)
 	err := grpc.Invoke(ctx, "/gopkg.in.bblfsh.sdk.v1.protocol.ProtocolService/Version", in, out, c.cc, opts...)
@@ -178,6 +212,8 @@ type ProtocolServiceServer interface {
 	NativeParse(context.Context, *NativeParseRequest) (*NativeParseResponse, error)
 	// Parse uses DefaultService to process the given parsing request to get the UAST.
 	Parse(context.Context, *ParseRequest) (*ParseResponse, error)
+	// SupportedLanguages uses DefaultService to process the given SupportedLanguagesRequest to get the supported drivers.
+	SupportedLanguages(context.Context, *SupportedLanguagesRequest) (*SupportedLanguagesResponse, error)
 	// Version uses DefaultVersioner to process the given version request to get the version.
 	Version(context.Context, *VersionRequest) (*VersionResponse, error)
 }
@@ -222,6 +258,24 @@ func _ProtocolService_Parse_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ProtocolService_SupportedLanguages_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SupportedLanguagesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ProtocolServiceServer).SupportedLanguages(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gopkg.in.bblfsh.sdk.v1.protocol.ProtocolService/SupportedLanguages",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ProtocolServiceServer).SupportedLanguages(ctx, req.(*SupportedLanguagesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ProtocolService_Version_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(VersionRequest)
 	if err := dec(in); err != nil {
@@ -253,12 +307,73 @@ var _ProtocolService_serviceDesc = grpc.ServiceDesc{
 			Handler:    _ProtocolService_Parse_Handler,
 		},
 		{
+			MethodName: "SupportedLanguages",
+			Handler:    _ProtocolService_SupportedLanguages_Handler,
+		},
+		{
 			MethodName: "Version",
 			Handler:    _ProtocolService_Version_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "gopkg.in/bblfsh/sdk.v1/protocol/generated.proto",
+}
+
+func (m *DriverManifest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DriverManifest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Name) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintGenerated(dAtA, i, uint64(len(m.Name)))
+		i += copy(dAtA[i:], m.Name)
+	}
+	if len(m.Language) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintGenerated(dAtA, i, uint64(len(m.Language)))
+		i += copy(dAtA[i:], m.Language)
+	}
+	if len(m.Version) > 0 {
+		dAtA[i] = 0x1a
+		i++
+		i = encodeVarintGenerated(dAtA, i, uint64(len(m.Version)))
+		i += copy(dAtA[i:], m.Version)
+	}
+	if len(m.Status) > 0 {
+		dAtA[i] = 0x22
+		i++
+		i = encodeVarintGenerated(dAtA, i, uint64(len(m.Status)))
+		i += copy(dAtA[i:], m.Status)
+	}
+	if len(m.Features) > 0 {
+		for _, s := range m.Features {
+			dAtA[i] = 0x2a
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	return i, nil
 }
 
 func (m *NativeParseRequest) Marshal() (dAtA []byte, err error) {
@@ -301,8 +416,8 @@ func (m *NativeParseRequest) MarshalTo(dAtA []byte) (int, error) {
 	}
 	dAtA[i] = 0x2a
 	i++
-	i = encodeVarintGenerated(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.Timeout)))
-	n1, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Timeout, dAtA[i:])
+	i = encodeVarintGenerated(dAtA, i, uint64(types.SizeOfStdDuration(m.Timeout)))
+	n1, err := types.StdDurationMarshalTo(m.Timeout, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -347,8 +462,8 @@ func (m *NativeParseResponse) MarshalTo(dAtA []byte) (int, error) {
 	}
 	dAtA[i] = 0x1a
 	i++
-	i = encodeVarintGenerated(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.Elapsed)))
-	n2, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Elapsed, dAtA[i:])
+	i = encodeVarintGenerated(dAtA, i, uint64(types.SizeOfStdDuration(m.Elapsed)))
+	n2, err := types.StdDurationMarshalTo(m.Elapsed, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -408,8 +523,8 @@ func (m *ParseRequest) MarshalTo(dAtA []byte) (int, error) {
 	}
 	dAtA[i] = 0x2a
 	i++
-	i = encodeVarintGenerated(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.Timeout)))
-	n3, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Timeout, dAtA[i:])
+	i = encodeVarintGenerated(dAtA, i, uint64(types.SizeOfStdDuration(m.Timeout)))
+	n3, err := types.StdDurationMarshalTo(m.Timeout, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -454,8 +569,8 @@ func (m *ParseResponse) MarshalTo(dAtA []byte) (int, error) {
 	}
 	dAtA[i] = 0x1a
 	i++
-	i = encodeVarintGenerated(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.Elapsed)))
-	n4, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Elapsed, dAtA[i:])
+	i = encodeVarintGenerated(dAtA, i, uint64(types.SizeOfStdDuration(m.Elapsed)))
+	n4, err := types.StdDurationMarshalTo(m.Elapsed, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -475,6 +590,88 @@ func (m *ParseResponse) MarshalTo(dAtA []byte) (int, error) {
 		i++
 		i = encodeVarintGenerated(dAtA, i, uint64(len(m.Language)))
 		i += copy(dAtA[i:], m.Language)
+	}
+	if len(m.Filename) > 0 {
+		dAtA[i] = 0x32
+		i++
+		i = encodeVarintGenerated(dAtA, i, uint64(len(m.Filename)))
+		i += copy(dAtA[i:], m.Filename)
+	}
+	return i, nil
+}
+
+func (m *SupportedLanguagesRequest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SupportedLanguagesRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *SupportedLanguagesResponse) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SupportedLanguagesResponse) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Status != 0 {
+		dAtA[i] = 0x8
+		i++
+		i = encodeVarintGenerated(dAtA, i, uint64(m.Status))
+	}
+	if len(m.Errors) > 0 {
+		for _, s := range m.Errors {
+			dAtA[i] = 0x12
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	dAtA[i] = 0x1a
+	i++
+	i = encodeVarintGenerated(dAtA, i, uint64(types.SizeOfStdDuration(m.Elapsed)))
+	n6, err := types.StdDurationMarshalTo(m.Elapsed, dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n6
+	if len(m.Languages) > 0 {
+		for _, msg := range m.Languages {
+			dAtA[i] = 0x22
+			i++
+			i = encodeVarintGenerated(dAtA, i, uint64(msg.ProtoSize()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
 	}
 	return i, nil
 }
@@ -534,12 +731,12 @@ func (m *VersionResponse) MarshalTo(dAtA []byte) (int, error) {
 	}
 	dAtA[i] = 0x1a
 	i++
-	i = encodeVarintGenerated(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.Elapsed)))
-	n6, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Elapsed, dAtA[i:])
+	i = encodeVarintGenerated(dAtA, i, uint64(types.SizeOfStdDuration(m.Elapsed)))
+	n7, err := types.StdDurationMarshalTo(m.Elapsed, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n6
+	i += n7
 	if len(m.Version) > 0 {
 		dAtA[i] = 0x22
 		i++
@@ -548,33 +745,15 @@ func (m *VersionResponse) MarshalTo(dAtA []byte) (int, error) {
 	}
 	dAtA[i] = 0x2a
 	i++
-	i = encodeVarintGenerated(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Build)))
-	n7, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Build, dAtA[i:])
+	i = encodeVarintGenerated(dAtA, i, uint64(types.SizeOfStdTime(m.Build)))
+	n8, err := types.StdTimeMarshalTo(m.Build, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n7
+	i += n8
 	return i, nil
 }
 
-func encodeFixed64Generated(dAtA []byte, offset int, v uint64) int {
-	dAtA[offset] = uint8(v)
-	dAtA[offset+1] = uint8(v >> 8)
-	dAtA[offset+2] = uint8(v >> 16)
-	dAtA[offset+3] = uint8(v >> 24)
-	dAtA[offset+4] = uint8(v >> 32)
-	dAtA[offset+5] = uint8(v >> 40)
-	dAtA[offset+6] = uint8(v >> 48)
-	dAtA[offset+7] = uint8(v >> 56)
-	return offset + 8
-}
-func encodeFixed32Generated(dAtA []byte, offset int, v uint32) int {
-	dAtA[offset] = uint8(v)
-	dAtA[offset+1] = uint8(v >> 8)
-	dAtA[offset+2] = uint8(v >> 16)
-	dAtA[offset+3] = uint8(v >> 24)
-	return offset + 4
-}
 func encodeVarintGenerated(dAtA []byte, offset int, v uint64) int {
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
@@ -584,6 +763,34 @@ func encodeVarintGenerated(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return offset + 1
 }
+func (m *DriverManifest) ProtoSize() (n int) {
+	var l int
+	_ = l
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + sovGenerated(uint64(l))
+	}
+	l = len(m.Language)
+	if l > 0 {
+		n += 1 + l + sovGenerated(uint64(l))
+	}
+	l = len(m.Version)
+	if l > 0 {
+		n += 1 + l + sovGenerated(uint64(l))
+	}
+	l = len(m.Status)
+	if l > 0 {
+		n += 1 + l + sovGenerated(uint64(l))
+	}
+	if len(m.Features) > 0 {
+		for _, s := range m.Features {
+			l = len(s)
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
+	return n
+}
+
 func (m *NativeParseRequest) ProtoSize() (n int) {
 	var l int
 	_ = l
@@ -602,7 +809,7 @@ func (m *NativeParseRequest) ProtoSize() (n int) {
 	if m.Encoding != 0 {
 		n += 1 + sovGenerated(uint64(m.Encoding))
 	}
-	l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Timeout)
+	l = types.SizeOfStdDuration(m.Timeout)
 	n += 1 + l + sovGenerated(uint64(l))
 	return n
 }
@@ -619,7 +826,7 @@ func (m *NativeParseResponse) ProtoSize() (n int) {
 			n += 1 + l + sovGenerated(uint64(l))
 		}
 	}
-	l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Elapsed)
+	l = types.SizeOfStdDuration(m.Elapsed)
 	n += 1 + l + sovGenerated(uint64(l))
 	l = len(m.AST)
 	if l > 0 {
@@ -650,7 +857,7 @@ func (m *ParseRequest) ProtoSize() (n int) {
 	if m.Encoding != 0 {
 		n += 1 + sovGenerated(uint64(m.Encoding))
 	}
-	l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Timeout)
+	l = types.SizeOfStdDuration(m.Timeout)
 	n += 1 + l + sovGenerated(uint64(l))
 	return n
 }
@@ -667,7 +874,7 @@ func (m *ParseResponse) ProtoSize() (n int) {
 			n += 1 + l + sovGenerated(uint64(l))
 		}
 	}
-	l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Elapsed)
+	l = types.SizeOfStdDuration(m.Elapsed)
 	n += 1 + l + sovGenerated(uint64(l))
 	if m.UAST != nil {
 		l = m.UAST.ProtoSize()
@@ -676,6 +883,39 @@ func (m *ParseResponse) ProtoSize() (n int) {
 	l = len(m.Language)
 	if l > 0 {
 		n += 1 + l + sovGenerated(uint64(l))
+	}
+	l = len(m.Filename)
+	if l > 0 {
+		n += 1 + l + sovGenerated(uint64(l))
+	}
+	return n
+}
+
+func (m *SupportedLanguagesRequest) ProtoSize() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *SupportedLanguagesResponse) ProtoSize() (n int) {
+	var l int
+	_ = l
+	if m.Status != 0 {
+		n += 1 + sovGenerated(uint64(m.Status))
+	}
+	if len(m.Errors) > 0 {
+		for _, s := range m.Errors {
+			l = len(s)
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
+	l = types.SizeOfStdDuration(m.Elapsed)
+	n += 1 + l + sovGenerated(uint64(l))
+	if len(m.Languages) > 0 {
+		for _, e := range m.Languages {
+			l = e.ProtoSize()
+			n += 1 + l + sovGenerated(uint64(l))
+		}
 	}
 	return n
 }
@@ -698,13 +938,13 @@ func (m *VersionResponse) ProtoSize() (n int) {
 			n += 1 + l + sovGenerated(uint64(l))
 		}
 	}
-	l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Elapsed)
+	l = types.SizeOfStdDuration(m.Elapsed)
 	n += 1 + l + sovGenerated(uint64(l))
 	l = len(m.Version)
 	if l > 0 {
 		n += 1 + l + sovGenerated(uint64(l))
 	}
-	l = github_com_gogo_protobuf_types.SizeOfStdTime(m.Build)
+	l = types.SizeOfStdTime(m.Build)
 	n += 1 + l + sovGenerated(uint64(l))
 	return n
 }
@@ -721,6 +961,201 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *DriverManifest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DriverManifest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DriverManifest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Language", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Language = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Version = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Status", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Status = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Features", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Features = append(m.Features, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 func (m *NativeParseRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
@@ -883,7 +1318,7 @@ func (m *NativeParseRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := github_com_gogo_protobuf_types.StdDurationUnmarshal(&m.Timeout, dAtA[iNdEx:postIndex]); err != nil {
+			if err := types.StdDurationUnmarshal(&m.Timeout, dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -1011,7 +1446,7 @@ func (m *NativeParseResponse) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := github_com_gogo_protobuf_types.StdDurationUnmarshal(&m.Elapsed, dAtA[iNdEx:postIndex]); err != nil {
+			if err := types.StdDurationUnmarshal(&m.Elapsed, dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -1255,7 +1690,7 @@ func (m *ParseRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := github_com_gogo_protobuf_types.StdDurationUnmarshal(&m.Timeout, dAtA[iNdEx:postIndex]); err != nil {
+			if err := types.StdDurationUnmarshal(&m.Timeout, dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -1383,7 +1818,7 @@ func (m *ParseResponse) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := github_com_gogo_protobuf_types.StdDurationUnmarshal(&m.Elapsed, dAtA[iNdEx:postIndex]); err != nil {
+			if err := types.StdDurationUnmarshal(&m.Elapsed, dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -1448,6 +1883,244 @@ func (m *ParseResponse) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Language = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Filename", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Filename = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SupportedLanguagesRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SupportedLanguagesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SupportedLanguagesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SupportedLanguagesResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SupportedLanguagesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SupportedLanguagesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Status", wireType)
+			}
+			m.Status = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Status |= (Status(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Errors", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Errors = append(m.Errors, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Elapsed", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := types.StdDurationUnmarshal(&m.Elapsed, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Languages", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Languages = append(m.Languages, DriverManifest{})
+			if err := m.Languages[len(m.Languages)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -1623,7 +2296,7 @@ func (m *VersionResponse) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := github_com_gogo_protobuf_types.StdDurationUnmarshal(&m.Elapsed, dAtA[iNdEx:postIndex]); err != nil {
+			if err := types.StdDurationUnmarshal(&m.Elapsed, dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -1682,7 +2355,7 @@ func (m *VersionResponse) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := github_com_gogo_protobuf_types.StdTimeUnmarshal(&m.Build, dAtA[iNdEx:postIndex]); err != nil {
+			if err := types.StdTimeUnmarshal(&m.Build, dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -1817,51 +2490,59 @@ func init() {
 }
 
 var fileDescriptorGenerated = []byte{
-	// 723 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0x94, 0xcd, 0x4e, 0xdb, 0x4a,
-	0x14, 0xc7, 0x6d, 0xe7, 0xcb, 0x19, 0xb8, 0x21, 0x9a, 0x7b, 0x75, 0x65, 0xbc, 0xb0, 0x7d, 0xd9,
-	0xdc, 0x94, 0x0a, 0xa7, 0x0d, 0x08, 0x55, 0x48, 0x15, 0x4a, 0x44, 0xd8, 0xb4, 0x02, 0xe4, 0x84,
-	0x2e, 0xba, 0x9b, 0x24, 0x13, 0x63, 0xe1, 0x78, 0x52, 0xcf, 0x38, 0xea, 0x23, 0xd0, 0xac, 0xaa,
-	0xae, 0xd8, 0x44, 0xa2, 0x2a, 0x8b, 0x3e, 0x46, 0x97, 0x2c, 0xfb, 0x04, 0xb4, 0x0d, 0x2f, 0x80,
-	0xba, 0xe8, 0xba, 0xb2, 0xc7, 0x06, 0x02, 0x42, 0x81, 0x5d, 0xab, 0xee, 0x7c, 0xe6, 0x9c, 0xdf,
-	0x99, 0x73, 0xfe, 0xe7, 0x78, 0x40, 0xd9, 0x26, 0xfd, 0x7d, 0xdb, 0x74, 0xbc, 0x72, 0xab, 0xe5,
-	0x76, 0xe9, 0x5e, 0x99, 0x76, 0xf6, 0xcd, 0xc1, 0xe3, 0x72, 0xdf, 0x27, 0x8c, 0xb4, 0x89, 0x5b,
-	0xb6, 0xb1, 0x87, 0x7d, 0xc4, 0x70, 0xc7, 0x8c, 0x8e, 0xa0, 0x9e, 0x00, 0x26, 0x07, 0x4c, 0x0e,
-	0x98, 0x09, 0xa0, 0x2e, 0xd9, 0x0e, 0xdb, 0x0b, 0x5a, 0x66, 0x9b, 0xf4, 0xca, 0x36, 0xb1, 0x09,
-	0x4f, 0xd5, 0x0a, 0xba, 0x91, 0x15, 0x19, 0xd1, 0x17, 0x27, 0x54, 0xcd, 0x26, 0xc4, 0x76, 0xf1,
-	0x65, 0x54, 0x27, 0xf0, 0x11, 0x73, 0x88, 0x17, 0xfb, 0x1f, 0xde, 0x52, 0x60, 0x80, 0x28, 0xbb,
-	0x5e, 0x9c, 0xaa, 0x5f, 0x4f, 0xc6, 0x9c, 0x1e, 0xa6, 0x0c, 0xf5, 0xfa, 0x3c, 0x60, 0xe1, 0x87,
-	0x08, 0xe0, 0x16, 0x62, 0xce, 0x00, 0xef, 0x20, 0x9f, 0x62, 0x0b, 0xbf, 0x0a, 0x30, 0x65, 0x50,
-	0x05, 0x72, 0xd7, 0x71, 0xb1, 0x87, 0x7a, 0x58, 0x11, 0x0d, 0xb1, 0x94, 0xb7, 0x2e, 0xec, 0xd0,
-	0xe7, 0x22, 0xcf, 0x0e, 0x90, 0x8d, 0x15, 0x89, 0xfb, 0x12, 0x1b, 0x2a, 0x20, 0xd7, 0x26, 0x1e,
-	0xc3, 0x1e, 0x53, 0x52, 0x91, 0x2b, 0x31, 0x61, 0x1d, 0xc8, 0xd8, 0x6b, 0x93, 0x8e, 0xe3, 0xd9,
-	0x4a, 0xda, 0x10, 0x4b, 0x85, 0xca, 0x03, 0x73, 0x8a, 0x72, 0x66, 0x3d, 0x06, 0xac, 0x0b, 0x14,
-	0x3e, 0x05, 0xb9, 0xb0, 0x05, 0x12, 0x30, 0x25, 0x63, 0x88, 0xa5, 0x99, 0xca, 0xbc, 0xc9, 0x5b,
-	0x34, 0x93, 0x16, 0xcd, 0x8d, 0x58, 0xaf, 0x9a, 0x7c, 0x72, 0xaa, 0x0b, 0x87, 0x5f, 0x74, 0xd1,
-	0x4a, 0x98, 0x35, 0xf9, 0xe0, 0x48, 0x17, 0xce, 0xdf, 0xeb, 0xc2, 0xc2, 0x77, 0x11, 0xfc, 0x3d,
-	0xd1, 0x38, 0xed, 0x13, 0x8f, 0x62, 0xb8, 0x0e, 0xb2, 0x94, 0x21, 0x16, 0xd0, 0xa8, 0xef, 0x42,
-	0xe5, 0xff, 0xa9, 0x55, 0x36, 0xa2, 0x70, 0x2b, 0xc6, 0xe0, 0xbf, 0x20, 0x8b, 0x7d, 0x9f, 0xf8,
-	0x54, 0x91, 0x8c, 0x54, 0x29, 0x6f, 0xc5, 0x56, 0x58, 0x39, 0x76, 0x51, 0x9f, 0xe2, 0x4e, 0x24,
-	0xcd, 0x5d, 0x2b, 0x8f, 0x19, 0x38, 0x0f, 0x52, 0x88, 0xb2, 0x48, 0xba, 0x7c, 0x2d, 0x37, 0x3e,
-	0xd5, 0x53, 0xd5, 0x46, 0xd3, 0x0a, 0xcf, 0x26, 0x06, 0x92, 0x99, 0x1c, 0xc8, 0xda, 0x6c, 0xd8,
-	0xf0, 0x61, 0xd2, 0xf4, 0xb9, 0x08, 0x66, 0xff, 0xb0, 0x39, 0xbf, 0x93, 0xc0, 0x5f, 0xbf, 0xc7,
-	0x84, 0xd7, 0x41, 0x3a, 0x48, 0x46, 0x3c, 0x53, 0xf9, 0xef, 0xb6, 0xaa, 0xc2, 0x18, 0x73, 0x8b,
-	0x74, 0x70, 0x4d, 0x1e, 0x9f, 0xea, 0xe9, 0xdd, 0x70, 0x0d, 0x22, 0xf0, 0x1e, 0x7b, 0xa0, 0x82,
-	0xc2, 0x0b, 0xec, 0x53, 0x87, 0x78, 0xf1, 0x22, 0x5c, 0x11, 0xec, 0x8d, 0x04, 0xe6, 0x2e, 0x9c,
-	0xbf, 0xb8, 0x64, 0x0a, 0xc8, 0x0d, 0x78, 0xa9, 0xfc, 0xc7, 0xb0, 0x12, 0x13, 0xae, 0x81, 0x4c,
-	0x2b, 0x70, 0xdc, 0x4e, 0xbc, 0x3d, 0xea, 0x8d, 0xb4, 0xcd, 0xe4, 0x21, 0xe4, 0x79, 0xdf, 0x86,
-	0x79, 0x39, 0x72, 0xa9, 0xc5, 0xe2, 0x06, 0x90, 0x93, 0xdd, 0x84, 0x10, 0xa4, 0x77, 0x9b, 0x9b,
-	0x4f, 0x8a, 0x82, 0x2a, 0x0f, 0x47, 0x46, 0xf4, 0x1d, 0xb6, 0x55, 0xab, 0x36, 0xea, 0xab, 0x2b,
-	0x45, 0x51, 0x05, 0xc3, 0x91, 0x91, 0xad, 0x21, 0x8a, 0x57, 0x57, 0xd4, 0xd9, 0x83, 0x0f, 0x9a,
-	0xf0, 0xf1, 0x58, 0x13, 0x3e, 0x1d, 0x6b, 0xc2, 0xa2, 0x05, 0xb2, 0x5c, 0x0e, 0x58, 0x00, 0xd2,
-	0xf6, 0xb3, 0xa2, 0xa0, 0x66, 0x87, 0x23, 0x43, 0xda, 0xde, 0x87, 0xff, 0x80, 0x4c, 0xdd, 0xb2,
-	0xb6, 0xad, 0xa2, 0xa8, 0xe6, 0x87, 0x23, 0x23, 0x53, 0x0f, 0x55, 0x09, 0x4f, 0x37, 0xab, 0xcd,
-	0xea, 0xf3, 0xa2, 0xc4, 0x4f, 0x37, 0x11, 0x43, 0xee, 0x64, 0xce, 0xca, 0x37, 0x09, 0xcc, 0xed,
-	0xc4, 0x62, 0x37, 0xb0, 0x3f, 0x70, 0xda, 0x18, 0xbe, 0x06, 0x33, 0x57, 0x5e, 0x34, 0xb8, 0x3c,
-	0x75, 0x48, 0x37, 0x1f, 0x7e, 0x75, 0xe5, 0x7e, 0x50, 0xbc, 0x1f, 0x5d, 0x90, 0xe1, 0x77, 0x2e,
-	0x4d, 0xc5, 0x27, 0x6e, 0x33, 0xef, 0x1a, 0x1e, 0xdf, 0xe3, 0x82, 0x5c, 0xbc, 0x9a, 0xb0, 0x3c,
-	0x15, 0x9d, 0xdc, 0x70, 0xf5, 0xd1, 0xdd, 0x01, 0x7e, 0x5b, 0x4d, 0x3b, 0x19, 0x6b, 0xe2, 0xe7,
-	0xb1, 0x26, 0x7e, 0x1d, 0x6b, 0xc2, 0xe1, 0x99, 0x26, 0x1c, 0x9d, 0x69, 0xe2, 0x4b, 0x39, 0x89,
-	0x6f, 0x65, 0xa3, 0xaf, 0xe5, 0x9f, 0x01, 0x00, 0x00, 0xff, 0xff, 0x2c, 0xfe, 0xdc, 0x28, 0x33,
-	0x08, 0x00, 0x00,
+	// 849 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0x55, 0x4f, 0x8f, 0xdb, 0x44,
+	0x14, 0xb7, 0x9d, 0x7f, 0xde, 0xc9, 0x92, 0x46, 0x03, 0xaa, 0xbc, 0x3e, 0xd8, 0xa1, 0x12, 0x62,
+	0x29, 0xaa, 0x03, 0xe9, 0xaa, 0x42, 0x41, 0xa8, 0x4a, 0xb4, 0xd9, 0x0b, 0xa5, 0x5b, 0x39, 0x29,
+	0x07, 0x6e, 0x93, 0x78, 0xe2, 0x5a, 0xeb, 0x78, 0x82, 0x67, 0x1c, 0xf1, 0x11, 0x4a, 0x24, 0x24,
+	0x24, 0x2e, 0xb9, 0x44, 0x2a, 0xa2, 0x07, 0x4e, 0x7c, 0x06, 0x8e, 0x3d, 0xf2, 0x09, 0x16, 0x94,
+	0xfd, 0x02, 0x0b, 0x07, 0xce, 0x68, 0xc6, 0x76, 0x36, 0xde, 0xb0, 0x78, 0xe1, 0xb4, 0xa8, 0xb7,
+	0x79, 0x33, 0xef, 0xf7, 0xe6, 0x37, 0xbf, 0xf7, 0xde, 0x3c, 0xd0, 0x74, 0xc9, 0xf4, 0xc4, 0xb5,
+	0xbc, 0xa0, 0x39, 0x1c, 0xfa, 0x63, 0xfa, 0xac, 0x49, 0x9d, 0x13, 0x6b, 0xf6, 0x61, 0x73, 0x1a,
+	0x12, 0x46, 0x46, 0xc4, 0x6f, 0xba, 0x38, 0xc0, 0x21, 0x62, 0xd8, 0xb1, 0xc4, 0x16, 0x34, 0x53,
+	0x80, 0x15, 0x03, 0xac, 0x18, 0x60, 0xa5, 0x00, 0xfd, 0x9e, 0xeb, 0xb1, 0x67, 0xd1, 0xd0, 0x1a,
+	0x91, 0x49, 0xd3, 0x25, 0x2e, 0x89, 0x43, 0x0d, 0xa3, 0xb1, 0xb0, 0x84, 0x21, 0x56, 0x31, 0x42,
+	0x37, 0x5c, 0x42, 0x5c, 0x1f, 0x5f, 0x78, 0x39, 0x51, 0x88, 0x98, 0x47, 0x82, 0xe4, 0xfc, 0xfd,
+	0x2b, 0x08, 0x46, 0x88, 0xb2, 0xcb, 0xe4, 0x74, 0xf3, 0x72, 0x30, 0xe6, 0x4d, 0x30, 0x65, 0x68,
+	0x32, 0x8d, 0x1d, 0xee, 0x2c, 0x64, 0x50, 0x3b, 0x0c, 0xbd, 0x19, 0x0e, 0x3f, 0x43, 0x81, 0x37,
+	0xc6, 0x94, 0x41, 0x08, 0x8a, 0x01, 0x9a, 0x60, 0x4d, 0x6e, 0xc8, 0xfb, 0x3b, 0xb6, 0x58, 0x43,
+	0x1d, 0xa8, 0x3e, 0x0a, 0xdc, 0x08, 0xb9, 0x58, 0x53, 0xc4, 0xfe, 0xda, 0x86, 0x1a, 0xa8, 0xcc,
+	0x70, 0x48, 0x3d, 0x12, 0x68, 0x05, 0x71, 0x94, 0x9a, 0xf0, 0x36, 0x28, 0x53, 0x86, 0x58, 0x44,
+	0xb5, 0xa2, 0x38, 0x48, 0x2c, 0x1e, 0x6d, 0x8c, 0x11, 0x8b, 0x42, 0x4c, 0xb5, 0x52, 0xa3, 0xc0,
+	0xa3, 0xa5, 0x76, 0x5b, 0x7d, 0xfe, 0xc2, 0x94, 0xce, 0xbf, 0x37, 0xa5, 0x3b, 0x7f, 0xca, 0x00,
+	0x3e, 0x46, 0xcc, 0x9b, 0xe1, 0x27, 0x28, 0xa4, 0xd8, 0xc6, 0x5f, 0x46, 0x9c, 0x1e, 0x07, 0x7b,
+	0x3e, 0xde, 0xa0, 0xb8, 0xb6, 0xf3, 0x68, 0x8e, 0x48, 0xc0, 0x70, 0xc0, 0x52, 0x9a, 0x89, 0x09,
+	0x7b, 0x40, 0xc5, 0xc1, 0x88, 0x38, 0x5e, 0xe0, 0x0a, 0xa2, 0xb5, 0xd6, 0x7b, 0x56, 0x4e, 0x52,
+	0xad, 0x5e, 0x02, 0xb0, 0xd7, 0x50, 0xf8, 0x09, 0xa8, 0x70, 0x75, 0x49, 0xc4, 0xb4, 0x52, 0x43,
+	0xde, 0xaf, 0xb6, 0xf6, 0xac, 0x58, 0x7d, 0x2b, 0x55, 0xdf, 0x3a, 0x4c, 0x52, 0xd9, 0x55, 0x5f,
+	0x9d, 0x9a, 0xd2, 0xe2, 0x57, 0x53, 0xb6, 0x53, 0xcc, 0xc6, 0xc3, 0xff, 0x90, 0xc1, 0x9b, 0x99,
+	0x87, 0xd3, 0x29, 0x09, 0x28, 0x86, 0x0f, 0xd7, 0x72, 0xca, 0x82, 0xe5, 0xbb, 0xb9, 0x2c, 0xfb,
+	0xc2, 0x7d, 0xad, 0xfb, 0x6d, 0x50, 0xc6, 0x61, 0x48, 0x42, 0xaa, 0x29, 0x42, 0xf5, 0xc4, 0xe2,
+	0xcc, 0xb1, 0x8f, 0xa6, 0x14, 0x3b, 0x42, 0x9a, 0xeb, 0x32, 0x4f, 0x30, 0x70, 0x0f, 0x14, 0x10,
+	0x65, 0x71, 0x8e, 0xbb, 0x95, 0xd5, 0xa9, 0x59, 0xe8, 0xf4, 0x07, 0x36, 0xdf, 0xcb, 0x24, 0xa4,
+	0x94, 0x4d, 0x48, 0x7b, 0x97, 0x3f, 0x78, 0x91, 0x3e, 0xfa, 0x5c, 0x06, 0xbb, 0xaf, 0x59, 0x9e,
+	0x7f, 0x52, 0xc0, 0x1b, 0xff, 0x8f, 0x0c, 0x3f, 0x04, 0xc5, 0x28, 0x4d, 0x71, 0xb5, 0xf5, 0xf6,
+	0x55, 0xac, 0xb8, 0x8f, 0xf5, 0x98, 0x38, 0xb8, 0xab, 0xae, 0x4e, 0xcd, 0xe2, 0x53, 0x5e, 0x06,
+	0x02, 0xf8, 0x4f, 0x75, 0x90, 0x49, 0x74, 0x39, 0x9b, 0xe8, 0x4b, 0x35, 0xf2, 0x0e, 0xd8, 0xeb,
+	0x47, 0xd3, 0x29, 0x09, 0x19, 0x76, 0x1e, 0x25, 0x70, 0x9a, 0xd4, 0xcb, 0x86, 0xae, 0xdf, 0x29,
+	0x40, 0xff, 0x3b, 0xbf, 0x1b, 0x2e, 0x72, 0x1f, 0xec, 0xa4, 0x9a, 0xf0, 0x0f, 0xb3, 0xb0, 0x5f,
+	0x6d, 0x35, 0x73, 0xa9, 0x65, 0xff, 0xee, 0x6e, 0x91, 0x87, 0xb5, 0x2f, 0xe2, 0x6c, 0xa8, 0xa2,
+	0x83, 0xda, 0xe7, 0xf1, 0xbf, 0xbc, 0xad, 0xd8, 0xd7, 0x0a, 0xb8, 0xb5, 0x3e, 0xbc, 0xe1, 0x32,
+	0x6d, 0x8c, 0x9b, 0x62, 0x76, 0xdc, 0xb4, 0x41, 0x69, 0x18, 0x79, 0xbe, 0x93, 0xb4, 0xa5, 0xbe,
+	0x15, 0x76, 0x90, 0x0e, 0xbf, 0x38, 0xee, 0xb7, 0x3c, 0x6e, 0x0c, 0xb9, 0xd0, 0xe2, 0xee, 0x21,
+	0x50, 0xd3, 0xa6, 0xe7, 0xa3, 0xf0, 0xe9, 0xe0, 0xe8, 0xa3, 0xba, 0xa4, 0xab, 0xf3, 0x65, 0x43,
+	0xac, 0xf9, 0xb3, 0xba, 0x9d, 0x7e, 0xef, 0xc1, 0x41, 0x5d, 0xd6, 0xc1, 0x7c, 0xd9, 0x28, 0x77,
+	0x11, 0xc5, 0x0f, 0x0e, 0xf4, 0xdd, 0xe7, 0x3f, 0x18, 0xd2, 0x8f, 0x2f, 0x0d, 0xe9, 0xe7, 0x97,
+	0x86, 0x74, 0xd7, 0x06, 0xe5, 0x58, 0x0e, 0x58, 0x03, 0xca, 0xf1, 0xa7, 0x75, 0x49, 0x2f, 0xcf,
+	0x97, 0x0d, 0xe5, 0xf8, 0x04, 0xbe, 0x05, 0x4a, 0x3d, 0xdb, 0x3e, 0xb6, 0xeb, 0xb2, 0xbe, 0x33,
+	0x5f, 0x36, 0x4a, 0x3d, 0xae, 0x0a, 0xdf, 0x3d, 0xea, 0x0c, 0x3a, 0x8f, 0xea, 0x4a, 0xbc, 0x7b,
+	0x84, 0x18, 0xf2, 0xb3, 0x31, 0x5b, 0xbf, 0x17, 0xc0, 0xad, 0x27, 0x89, 0xd8, 0x7d, 0x1c, 0xce,
+	0xbc, 0x11, 0x86, 0x5f, 0x81, 0xea, 0xc6, 0xa8, 0x80, 0xf7, 0x73, 0x93, 0xb4, 0x3d, 0x51, 0xf5,
+	0x83, 0x7f, 0x07, 0x4a, 0xea, 0x63, 0x0c, 0x4a, 0xf1, 0x9d, 0xf7, 0x72, 0xe1, 0x99, 0xdb, 0xac,
+	0xeb, 0xba, 0x27, 0xf7, 0x7c, 0x23, 0x03, 0xb8, 0xdd, 0xcd, 0xb0, 0x9d, 0x5f, 0x8e, 0x57, 0x7d,
+	0x15, 0xfa, 0xc7, 0xff, 0x09, 0x9b, 0xf0, 0xf1, 0x41, 0x25, 0x69, 0x15, 0x98, 0xdf, 0x9e, 0xd9,
+	0x8e, 0xd3, 0x3f, 0xb8, 0x3e, 0x20, 0xbe, 0xad, 0x6b, 0xbc, 0x5a, 0x19, 0xf2, 0x2f, 0x2b, 0x43,
+	0xfe, 0x6d, 0x65, 0x48, 0x8b, 0x33, 0x43, 0x7a, 0x71, 0x66, 0xc8, 0x5f, 0xa8, 0xa9, 0xff, 0xb0,
+	0x2c, 0x56, 0xf7, 0xff, 0x0a, 0x00, 0x00, 0xff, 0xff, 0xaa, 0xba, 0x3c, 0x05, 0xb7, 0x0a, 0x00,
+	0x00,
 }

--- a/vendor/gopkg.in/bblfsh/sdk.v1/protocol/generated.proto
+++ b/vendor/gopkg.in/bblfsh/sdk.v1/protocol/generated.proto
@@ -10,6 +10,17 @@ option (gogoproto.protosizer_all) = true;
 option (gogoproto.sizer_all) = false;
 option go_package = "protocol";
 
+// DriverManifest is the installed driver exported data
+message DriverManifest {
+	option (gogoproto.goproto_getters) = false;
+	option (gogoproto.typedecl) = false;
+	string name = 1;
+	string language = 2;
+	string version = 3;
+	string status = 4;
+	repeated string features = 5;
+}
+
 // NativeParseRequest is a request to parse a file and get its native AST.
 message NativeParseRequest {
 	option (gogoproto.goproto_getters) = false;
@@ -54,6 +65,23 @@ message ParseResponse {
 	google.protobuf.Duration elapsed = 3 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 	gopkg.in.bblfsh.sdk.v1.uast.Node uast = 4 [(gogoproto.customname) = "UAST"];
 	string language = 5;
+	string filename = 6;
+}
+
+// SupportedLanguagesRequest is a request to get the supported languages
+message SupportedLanguagesRequest {
+	option (gogoproto.goproto_getters) = false;
+	option (gogoproto.typedecl) = false;
+}
+
+// SupportedLanguagesResponse is the reply to SupportedLanguagesRequest
+message SupportedLanguagesResponse {
+	option (gogoproto.goproto_getters) = false;
+	option (gogoproto.typedecl) = false;
+	gopkg.in.bblfsh.sdk.v1.protocol.Status status = 1;
+	repeated string errors = 2;
+	google.protobuf.Duration elapsed = 3 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+	repeated gopkg.in.bblfsh.sdk.v1.protocol.DriverManifest languages = 4 [(gogoproto.nullable) = false];
 }
 
 // VersionRequest is a request to get server version
@@ -105,6 +133,8 @@ service ProtocolService {
 	rpc NativeParse (gopkg.in.bblfsh.sdk.v1.protocol.NativeParseRequest) returns (gopkg.in.bblfsh.sdk.v1.protocol.NativeParseResponse);
 	// Parse uses DefaultService to process the given parsing request to get the UAST.
 	rpc Parse (gopkg.in.bblfsh.sdk.v1.protocol.ParseRequest) returns (gopkg.in.bblfsh.sdk.v1.protocol.ParseResponse);
+	// SupportedLanguages uses DefaultService to process the given SupportedLanguagesRequest to get the supported drivers.
+	rpc SupportedLanguages (gopkg.in.bblfsh.sdk.v1.protocol.SupportedLanguagesRequest) returns (gopkg.in.bblfsh.sdk.v1.protocol.SupportedLanguagesResponse);
 	// Version uses DefaultVersioner to process the given version request to get the version.
 	rpc Version (gopkg.in.bblfsh.sdk.v1.protocol.VersionRequest) returns (gopkg.in.bblfsh.sdk.v1.protocol.VersionResponse);
 }

--- a/vendor/gopkg.in/bblfsh/sdk.v1/protocol/server.proteus.go
+++ b/vendor/gopkg.in/bblfsh/sdk.v1/protocol/server.proteus.go
@@ -20,6 +20,11 @@ func (s *protocolServiceServer) Parse(ctx context.Context, in *ParseRequest) (re
 	result = Parse(in)
 	return
 }
+func (s *protocolServiceServer) SupportedLanguages(ctx context.Context, in *SupportedLanguagesRequest) (result *SupportedLanguagesResponse, err error) {
+	result = new(SupportedLanguagesResponse)
+	result = SupportedLanguages(in)
+	return
+}
 func (s *protocolServiceServer) Version(ctx context.Context, in *VersionRequest) (result *VersionResponse, err error) {
 	result = new(VersionResponse)
 	result = Version(in)

--- a/vendor/gopkg.in/bblfsh/sdk.v1/protocol/service.go
+++ b/vendor/gopkg.in/bblfsh/sdk.v1/protocol/service.go
@@ -31,6 +31,16 @@ func Version(req *VersionRequest) *VersionResponse {
 	return DefaultService.Version(req)
 }
 
+// SupportedLanguages uses DefaultService to process the given SupportedLanguagesRequest to get the supported drivers.
+//proteus:generate
+func SupportedLanguages(req *SupportedLanguagesRequest) *SupportedLanguagesResponse {
+	if r := checkDefaultService(); r != nil {
+		return &SupportedLanguagesResponse{Response: *r}
+	}
+
+	return DefaultService.SupportedLanguages(req)
+}
+
 func checkDefaultService() *Response {
 	if DefaultService == nil {
 		return &Response{

--- a/vendor/gopkg.in/bblfsh/sdk.v1/protocol/stringer.go
+++ b/vendor/gopkg.in/bblfsh/sdk.v1/protocol/stringer.go
@@ -2,7 +2,7 @@
 
 package protocol
 
-import "fmt"
+import "strconv"
 
 const _Status_name = "OkErrorFatal"
 
@@ -10,7 +10,7 @@ var _Status_index = [...]uint8{0, 2, 7, 12}
 
 func (i Status) String() string {
 	if i >= Status(len(_Status_index)-1) {
-		return fmt.Sprintf("Status(%d)", i)
+		return "Status(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _Status_name[_Status_index[i]:_Status_index[i+1]]
 }
@@ -21,7 +21,7 @@ var _Encoding_index = [...]uint8{0, 4, 10}
 
 func (i Encoding) String() string {
 	if i >= Encoding(len(_Encoding_index)-1) {
-		return fmt.Sprintf("Encoding(%d)", i)
+		return "Encoding(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _Encoding_name[_Encoding_index[i]:_Encoding_index[i+1]]
 }

--- a/vendor/gopkg.in/bblfsh/sdk.v1/sdk/driver/driver.go
+++ b/vendor/gopkg.in/bblfsh/sdk.v1/sdk/driver/driver.go
@@ -54,6 +54,10 @@ func (d *Driver) Parse(req *protocol.ParseRequest) *protocol.ParseResponse {
 		r.Language = d.m.Language
 	}
 
+	if r.Filename == "" {
+		r.Filename = req.Filename
+	}
+
 	if r.Status == protocol.Fatal {
 		return r
 	}
@@ -148,4 +152,13 @@ func (d *Driver) Version(req *protocol.VersionRequest) *protocol.VersionResponse
 	}
 
 	return r
+}
+
+// SupportedLanguages handles a SupportedLanguagesRequest including information from the manifest.
+func (d *Driver) SupportedLanguages(req *protocol.SupportedLanguagesRequest) *protocol.SupportedLanguagesResponse {
+	return &protocol.SupportedLanguagesResponse{
+		Languages: []protocol.DriverManifest{
+			protocol.NewDriverManifest(d.m),
+		},
+	}
 }

--- a/vendor/gopkg.in/bblfsh/sdk.v1/uast/generated.pb.go
+++ b/vendor/gopkg.in/bblfsh/sdk.v1/uast/generated.pb.go
@@ -421,24 +421,6 @@ func (m *Position) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
-func encodeFixed64Generated(dAtA []byte, offset int, v uint64) int {
-	dAtA[offset] = uint8(v)
-	dAtA[offset+1] = uint8(v >> 8)
-	dAtA[offset+2] = uint8(v >> 16)
-	dAtA[offset+3] = uint8(v >> 24)
-	dAtA[offset+4] = uint8(v >> 32)
-	dAtA[offset+5] = uint8(v >> 40)
-	dAtA[offset+6] = uint8(v >> 48)
-	dAtA[offset+7] = uint8(v >> 56)
-	return offset + 8
-}
-func encodeFixed32Generated(dAtA []byte, offset int, v uint32) int {
-	dAtA[offset] = uint8(v)
-	dAtA[offset+1] = uint8(v >> 8)
-	dAtA[offset+2] = uint8(v >> 16)
-	dAtA[offset+3] = uint8(v >> 24)
-	return offset + 4
-}
 func encodeVarintGenerated(dAtA []byte, offset int, v uint64) int {
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)


### PR DESCRIPTION
Required by https://github.com/bblfsh/sdk/issues/253
Blocked by ~https://github.com/bblfsh/sdk/pull/259~
Blocks https://github.com/bblfsh/client-go/pull/57

(see https://github.com/bblfsh/sdk/pull/259 description)