### PR TITLE
bblfshctl: add driver remove --all

### DIFF
--- a/cmd/bblfshctl/cmd/driver_remove.go
+++ b/cmd/bblfshctl/cmd/driver_remove.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	DriverRemoveCommandDescription = "Removes a new driver for the given language"
+	DriverRemoveCommandDescription = "Removes the driver for the specified language"
 	DriverRemoveCommandHelp        = DriverRemoveCommandDescription
 )
 
@@ -18,25 +18,46 @@ type DriverRemoveCommand struct {
 		Language string `positional-arg-name:"language" description:"language supported by the driver"`
 	} `positional-args:"yes"`
 
+	All bool `long:"all" description:"removes all the installed drivers"`
+
 	DriverCommand
 }
 
 func (c *DriverRemoveCommand) Execute(args []string) error {
+	ctx := context.Background()
 	if err := c.ControlCommand.Execute(nil); err != nil {
 		return err
 	}
 
-	r, err := c.srv.RemoveDriver(context.Background(), &protocol.RemoveDriverRequest{
-		Language: c.Args.Language,
-	})
+	langs := []string{c.Args.Language}
+	if c.All {
+		r, err := c.srv.DriverStates(ctx, &protocol.DriverStatesRequest{})
+		if err != nil {
+			return err
+		}
 
-	if err == nil && len(r.Errors) == 0 {
-		return nil
+		if err != nil || len(r.Errors) > 0 {
+			for _, e := range r.Errors {
+				fmt.Fprintf(os.Stderr, "Error, %s\n", e)
+			}
+			return err
+		}
+
+		langs = make([]string, len(r.State))
+		for i, s := range r.State {
+			langs[i] = s.Language
+		}
 	}
 
-	for _, e := range r.Errors {
-		fmt.Fprintf(os.Stderr, "Error, %s\n", e)
-	}
+	for _, lang := range langs {
+		r, err := c.srv.RemoveDriver(ctx, &protocol.RemoveDriverRequest{Language: lang})
+		if err != nil || len(r.Errors) > 0 {
+			for _, e := range r.Errors {
+				fmt.Fprintf(os.Stderr, "Error, %s\n", e)
+			}
 
-	return err
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/bblfshctl/cmd/driver_remove.go
+++ b/cmd/bblfshctl/cmd/driver_remove.go
@@ -32,14 +32,11 @@ func (c *DriverRemoveCommand) Execute(args []string) error {
 	langs := []string{c.Args.Language}
 	if c.All {
 		r, err := c.srv.DriverStates(ctx, &protocol.DriverStatesRequest{})
-		if err != nil {
-			return err
-		}
-
 		if err != nil || len(r.Errors) > 0 {
 			for _, e := range r.Errors {
 				fmt.Fprintf(os.Stderr, "Error, %s\n", e)
 			}
+
 			return err
 		}
 


### PR DESCRIPTION
`bblfshctl driver remove --all` following the same convention as `bblfshctl driver install --all`.

Signed-off-by: Francesc Campoy <campoy@golang.org>