### PR TITLE
Expose HTTP API for parsing files and listing supported languages

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,6 +15,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/antchfx/xpath"
+  packages = ["."]
+  revision = "3de91f3991a1af6e495d49c9218318b5544b20e3"
+
+[[projects]]
+  branch = "master"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
@@ -563,6 +569,8 @@
     "uast/nodes",
     "uast/nodes/nodesproto",
     "uast/nodes/nodesproto/pio",
+    "uast/query",
+    "uast/query/xpath",
     "uast/role",
     "uast/transformer",
     "uast/yaml"
@@ -601,6 +609,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "05d4c9004aa4807d42e1f2d95d62478507cb32552d6a212de87cfe5d59e17e8e"
+  inputs-digest = "5ecca5a2ca180937b6adf20445a3c54895f3690f18b5241c579d71a904bbeeaf"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -564,10 +564,11 @@
     "uast/nodes/nodesproto",
     "uast/nodes/nodesproto/pio",
     "uast/role",
-    "uast/transformer"
+    "uast/transformer",
+    "uast/yaml"
   ]
-  revision = "85fd47713ba40fc3bffe4214090a552074841431"
-  version = "v2.2.3"
+  revision = "fab3b62f674a6845167c004dcc11f9143209da2a"
+  version = "v2.2.4"
 
 [[projects]]
   name = "gopkg.in/src-d/enry.v1"
@@ -594,11 +595,12 @@
 [[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "1be3d31502d6eabc0dd7ce5b0daab022e14a5538"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0ce593b44932fe3a3e2e6891a7bf8c343416bad0ac01f84e5ad1e7a74c056d01"
+  inputs-digest = "05d4c9004aa4807d42e1f2d95d62478507cb32552d6a212de87cfe5d59e17e8e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ See the [Getting Started](https://doc.bblf.sh/using-babelfish/getting-started.ht
 The recommended way to run *bblfshd* is using *docker*:
 
 ```sh
-docker run -d --name bblfshd --privileged -p 9432:9432 -v /var/lib/bblfshd:/var/lib/bblfshd bblfsh/bblfshd
+docker run -d --name bblfshd --privileged -p 9432:9432 -p 9480:9480 -v /var/lib/bblfshd:/var/lib/bblfshd bblfsh/bblfshd
 ```
 
 On macOS, use this command instead to use a docker volume:
 
 ```sh
-docker run -d --name bblfshd --privileged -p 9432:9432 -v bblfsh-storage:/var/lib/bblfshd bblfsh/bblfshd
+docker run -d --name bblfshd --privileged -p 9432:9432 -p 9480:9480 -v bblfsh-storage:/var/lib/bblfshd bblfsh/bblfshd
 ```
 
 
@@ -38,7 +38,7 @@ Now you need to install the driver images into the daemon, you can install
 the official images just running the command:
 
 ```sh
-docker exec -it bblfshd bblfshctl driver install --all
+docker exec -it bblfshd bblfshctl driver install --recommended
 ```
 
 You can check the installed versions executing:
@@ -60,6 +60,11 @@ and an example contained in the docker image:
 
 ```sh
 docker exec -it bblfshd bblfshctl parse /opt/bblfsh/etc/examples/python.py
+```
+
+Parse request can also be sent as an HTTP POST:
+```sh
+curl --data-binary @./cmd/bblfshd/main.go -H 'Accept: application/json' 'http://localhost:9480/api/v1/parse?lang=go'
 ```
 
 ## SELinux

--- a/cmd/bblfshd/main.go
+++ b/cmd/bblfshd/main.go
@@ -304,7 +304,7 @@ func handleParse(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, err)
 		return
 	} else if len(data) > maxSize {
-		jsonError(w, http.StatusBadRequest, fmt.Errorf("content is too large"))
+		jsonError(w, http.StatusBadRequest, fmt.Errorf("content is too large (> %d MB)", *maxMessageSize))
 		return
 	}
 

--- a/vendor/github.com/antchfx/xpath/.gitignore
+++ b/vendor/github.com/antchfx/xpath/.gitignore
@@ -1,0 +1,32 @@
+# vscode
+.vscode
+debug
+*.test
+
+./build
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/antchfx/xpath/.travis.yml
+++ b/vendor/github.com/antchfx/xpath/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+
+go:
+  - 1.6
+  - 1.9
+  - '1.10'
+
+install:
+  - go get github.com/mattn/goveralls
+
+script:
+  - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/vendor/github.com/antchfx/xpath/LICENSE
+++ b/vendor/github.com/antchfx/xpath/LICENSE
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/antchfx/xpath/README.md
+++ b/vendor/github.com/antchfx/xpath/README.md
@@ -1,0 +1,155 @@
+XPath
+====
+[![GoDoc](https://godoc.org/github.com/antchfx/xpath?status.svg)](https://godoc.org/github.com/antchfx/xpath)
+[![Coverage Status](https://coveralls.io/repos/github/antchfx/xpath/badge.svg?branch=master)](https://coveralls.io/github/antchfx/xpath?branch=master)
+[![Build Status](https://travis-ci.org/antchfx/xpath.svg?branch=master)](https://travis-ci.org/antchfx/xpath)
+[![Go Report Card](https://goreportcard.com/badge/github.com/antchfx/xpath)](https://goreportcard.com/report/github.com/antchfx/xpath)
+
+XPath is Go package provides selecting nodes from XML, HTML or other documents using XPath expression.
+
+Implementation
+===
+
+- [htmlquery](https://github.com/antchfx/htmlquery) - an XPath query package for HTML document
+
+- [xmlquery](https://github.com/antchfx/xmlquery) - an XPath query package for XML document.
+
+- [jsonquery](https://github.com/antchfx/jsonquery) - an XPath query package for JSON document
+
+Supported Features
+===
+
+#### The basic XPath patterns.
+
+> The basic XPath patterns cover 90% of the cases that most stylesheets will need.
+
+- `node` : Selects all child elements with nodeName of node.
+
+- `*` : Selects all child elements.
+
+- `@attr` : Selects the attribute attr.
+
+- `@*` : Selects all attributes.
+
+- `node()` : Matches an org.w3c.dom.Node.
+
+- `text()` : Matches a org.w3c.dom.Text node.
+
+- `comment()` : Matches a comment.
+
+- `.` : Selects the current node.
+
+- `..` : Selects the parent of current node.
+
+- `/` : Selects the document node.
+
+- `a[expr]` : Select only those nodes matching a which also satisfy the expression expr.
+
+- `a[n]` : Selects the nth matching node matching a When a filter's expression is a number, XPath selects based on position.
+
+- `a/b` : For each node matching a, add the nodes matching b to the result.
+
+- `a//b` : For each node matching a, add the descendant nodes matching b to the result. 
+
+- `//b` : Returns elements in the entire document matching b.
+
+- `a|b` : All nodes matching a or b, union operation(not boolean or).
+
+#### Node Axes 
+
+- `child::*` : The child axis selects children of the current node.
+
+- `descendant::*` : The descendant axis selects descendants of the current node. It is equivalent to '//'.
+
+- `descendant-or-self::*` : Selects descendants including the current node.
+
+- `attribute::*` : Selects attributes of the current element. It is equivalent to @*
+
+- `following-sibling::*` : Selects nodes after the current node.
+
+- `preceding-sibling::*` : Selects nodes before the current node.
+
+- `following::*` : Selects the first matching node following in document order, excluding descendants. 
+
+- `preceding::*` : Selects the first matching node preceding in document order, excluding ancestors. 
+
+- `parent::*` : Selects the parent if it matches. The '..' pattern from the core is equivalent to 'parent::node()'.
+
+- `ancestor::*` : Selects matching ancestors.
+
+- `ancestor-or-self::*` : Selects ancestors including the current node.
+
+- `self::*` : Selects the current node. '.' is equivalent to 'self::node()'.
+
+#### Expressions
+
+ The gxpath supported three types: number, boolean, string.
+
+- `path` : Selects nodes based on the path.
+
+- `a = b` : Standard comparisons.
+
+    * a = b	    True if a equals b.
+    * a != b	True if a is not equal to b.
+    * a < b	    True if a is less than b.
+    * a <= b	True if a is less than or equal to b.
+    * a > b	    True if a is greater than b.
+    * a >= b	True if a is greater than or equal to b.
+
+- `a + b` : Arithmetic expressions.
+
+    * `- a`	Unary minus
+    * a + b	Add
+    * a - b	Substract
+    * a * b	Multiply
+    * a div b	Divide
+    * a mod b	Floating point mod, like Java.
+
+- `a or b` : Boolean `or` operation.
+
+- `a and b` : Boolean `and` operation.
+
+- `(expr)` : Parenthesized expressions.
+
+- `fun(arg1, ..., argn)` : Function calls:
+
+| Function | Supported |
+| --- | --- |
+`boolean()`| ✓ |
+`ceiling()`| ✓ |
+`choose()`| ✗ |
+`concat()`| ✓ |
+`contains()`| ✓ |
+`count()`| ✓ |
+`current()`| ✗ |
+`document()`| ✗ |
+`element-available()`| ✗ |
+`ends-with()`| ✓ |
+`false()`| ✓ |
+`floor()`| ✓ |
+`format-number()`| ✗ |
+`function-available()`| ✗ |
+`generate-id()`| ✗ |
+`id()`| ✗ |
+`key()`| ✗ |
+`lang()`| ✗ |
+`last()`| ✓ |
+`local-name()`| ✓ |
+`name()`| ✓ |
+`namespace-uri()`| ✓ |
+`normalize-space()`| ✓ |
+`not()`| ✓ |
+`number()`| ✓ |
+`position()`| ✓ |
+`round()`| ✓ |
+`starts-with()`| ✓ |
+`string()`| ✓ |
+`string-length()`| ✓ |
+`substring()`| ✓ |
+`substring-after()`| ✓ |
+`substring-before()`| ✓ |
+`sum()`| ✓ |
+`system-property()`| ✗ |
+`translate()`| ✓ |
+`true()`| ✓ |
+`unparsed-entity-url()` | ✗ |

--- a/vendor/github.com/antchfx/xpath/build.go
+++ b/vendor/github.com/antchfx/xpath/build.go
@@ -1,0 +1,483 @@
+package xpath
+
+import (
+	"errors"
+	"fmt"
+)
+
+type flag int
+
+const (
+	noneFlag flag = iota
+	filterFlag
+)
+
+// builder provides building an XPath expressions.
+type builder struct {
+	depth      int
+	flag       flag
+	firstInput query
+}
+
+// axisPredicate creates a predicate to predicating for this axis node.
+func axisPredicate(root *axisNode) func(NodeNavigator) bool {
+	// get current axix node type.
+	typ := ElementNode
+	switch root.AxeType {
+	case "attribute":
+		typ = AttributeNode
+	case "self", "parent":
+		typ = allNode
+	default:
+		switch root.Prop {
+		case "comment":
+			typ = CommentNode
+		case "text":
+			typ = TextNode
+			//	case "processing-instruction":
+		//	typ = ProcessingInstructionNode
+		case "node":
+			typ = allNode
+		}
+	}
+	nametest := root.LocalName != "" || root.Prefix != ""
+	predicate := func(n NodeNavigator) bool {
+		if typ == n.NodeType() || typ == allNode || typ == TextNode {
+			if nametest {
+				if root.LocalName == n.LocalName() && root.Prefix == n.Prefix() {
+					return true
+				}
+			} else {
+				return true
+			}
+		}
+		return false
+	}
+
+	return predicate
+}
+
+// processAxisNode processes a query for the XPath axis node.
+func (b *builder) processAxisNode(root *axisNode) (query, error) {
+	var (
+		err       error
+		qyInput   query
+		qyOutput  query
+		predicate = axisPredicate(root)
+	)
+
+	if root.Input == nil {
+		qyInput = &contextQuery{}
+	} else {
+		if root.AxeType == "child" && (root.Input.Type() == nodeAxis) {
+			if input := root.Input.(*axisNode); input.AxeType == "descendant-or-self" {
+				var qyGrandInput query
+				if input.Input != nil {
+					qyGrandInput, _ = b.processNode(input.Input)
+				} else {
+					qyGrandInput = &contextQuery{}
+				}
+				qyOutput = &descendantQuery{Input: qyGrandInput, Predicate: predicate, Self: true}
+				return qyOutput, nil
+			}
+		}
+		qyInput, err = b.processNode(root.Input)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	switch root.AxeType {
+	case "ancestor":
+		qyOutput = &ancestorQuery{Input: qyInput, Predicate: predicate}
+	case "ancestor-or-self":
+		qyOutput = &ancestorQuery{Input: qyInput, Predicate: predicate, Self: true}
+	case "attribute":
+		qyOutput = &attributeQuery{Input: qyInput, Predicate: predicate}
+	case "child":
+		filter := func(n NodeNavigator) bool {
+			v := predicate(n)
+			switch root.Prop {
+			case "text":
+				v = v && n.NodeType() == TextNode
+			case "node":
+				v = v && (n.NodeType() == ElementNode || n.NodeType() == TextNode)
+			case "comment":
+				v = v && n.NodeType() == CommentNode
+			}
+			return v
+		}
+		qyOutput = &childQuery{Input: qyInput, Predicate: filter}
+	case "descendant":
+		qyOutput = &descendantQuery{Input: qyInput, Predicate: predicate}
+	case "descendant-or-self":
+		qyOutput = &descendantQuery{Input: qyInput, Predicate: predicate, Self: true}
+	case "following":
+		qyOutput = &followingQuery{Input: qyInput, Predicate: predicate}
+	case "following-sibling":
+		qyOutput = &followingQuery{Input: qyInput, Predicate: predicate, Sibling: true}
+	case "parent":
+		qyOutput = &parentQuery{Input: qyInput, Predicate: predicate}
+	case "preceding":
+		qyOutput = &precedingQuery{Input: qyInput, Predicate: predicate}
+	case "preceding-sibling":
+		qyOutput = &precedingQuery{Input: qyInput, Predicate: predicate, Sibling: true}
+	case "self":
+		qyOutput = &selfQuery{Input: qyInput, Predicate: predicate}
+	case "namespace":
+		// haha,what will you do someting??
+	default:
+		err = fmt.Errorf("unknown axe type: %s", root.AxeType)
+		return nil, err
+	}
+	return qyOutput, nil
+}
+
+// processFilterNode builds query for the XPath filter predicate.
+func (b *builder) processFilterNode(root *filterNode) (query, error) {
+	b.flag |= filterFlag
+
+	qyInput, err := b.processNode(root.Input)
+	if err != nil {
+		return nil, err
+	}
+	qyCond, err := b.processNode(root.Condition)
+	if err != nil {
+		return nil, err
+	}
+	qyOutput := &filterQuery{Input: qyInput, Predicate: qyCond}
+	return qyOutput, nil
+}
+
+// processFunctionNode processes query for the XPath function node.
+func (b *builder) processFunctionNode(root *functionNode) (query, error) {
+	var qyOutput query
+	switch root.FuncName {
+	case "starts-with":
+		arg1, err := b.processNode(root.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		arg2, err := b.processNode(root.Args[1])
+		if err != nil {
+			return nil, err
+		}
+		qyOutput = &functionQuery{Input: b.firstInput, Func: startwithFunc(arg1, arg2)}
+	case "ends-with":
+		arg1, err := b.processNode(root.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		arg2, err := b.processNode(root.Args[1])
+		if err != nil {
+			return nil, err
+		}
+		qyOutput = &functionQuery{Input: b.firstInput, Func: endwithFunc(arg1, arg2)}
+	case "contains":
+		arg1, err := b.processNode(root.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		arg2, err := b.processNode(root.Args[1])
+		if err != nil {
+			return nil, err
+		}
+
+		qyOutput = &functionQuery{Input: b.firstInput, Func: containsFunc(arg1, arg2)}
+	case "substring":
+		//substring( string , start [, length] )
+		if len(root.Args) < 2 {
+			return nil, errors.New("xpath: substring function must have at least two parameter")
+		}
+		var (
+			arg1, arg2, arg3 query
+			err              error
+		)
+		if arg1, err = b.processNode(root.Args[0]); err != nil {
+			return nil, err
+		}
+		if arg2, err = b.processNode(root.Args[1]); err != nil {
+			return nil, err
+		}
+		if len(root.Args) == 3 {
+			if arg3, err = b.processNode(root.Args[2]); err != nil {
+				return nil, err
+			}
+		}
+		qyOutput = &functionQuery{Input: b.firstInput, Func: substringFunc(arg1, arg2, arg3)}
+	case "substring-before", "substring-after":
+		//substring-xxxx( haystack, needle )
+		if len(root.Args) != 2 {
+			return nil, errors.New("xpath: substring-before function must have two parameters")
+		}
+		var (
+			arg1, arg2 query
+			err        error
+		)
+		if arg1, err = b.processNode(root.Args[0]); err != nil {
+			return nil, err
+		}
+		if arg2, err = b.processNode(root.Args[1]); err != nil {
+			return nil, err
+		}
+		qyOutput = &functionQuery{
+			Input: b.firstInput,
+			Func:  substringIndFunc(arg1, arg2, root.FuncName == "substring-after"),
+		}
+	case "string-length":
+		// string-length( [string] )
+		if len(root.Args) < 1 {
+			return nil, errors.New("xpath: string-length function must have at least one parameter")
+		}
+		arg1, err := b.processNode(root.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		qyOutput = &functionQuery{Input: b.firstInput, Func: stringLengthFunc(arg1)}
+	case "normalize-space":
+		if len(root.Args) == 0 {
+			return nil, errors.New("xpath: normalize-space function must have at least one parameter")
+		}
+		argQuery, err := b.processNode(root.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		qyOutput = &functionQuery{Input: argQuery, Func: normalizespaceFunc}
+	case "translate":
+		//translate( string , string, string )
+		if len(root.Args) != 3 {
+			return nil, errors.New("xpath: translate function must have three parameters")
+		}
+		var (
+			arg1, arg2, arg3 query
+			err              error
+		)
+		if arg1, err = b.processNode(root.Args[0]); err != nil {
+			return nil, err
+		}
+		if arg2, err = b.processNode(root.Args[1]); err != nil {
+			return nil, err
+		}
+		if arg3, err = b.processNode(root.Args[2]); err != nil {
+			return nil, err
+		}
+		qyOutput = &functionQuery{Input: b.firstInput, Func: translateFunc(arg1, arg2, arg3)}
+	case "not":
+		if len(root.Args) == 0 {
+			return nil, errors.New("xpath: not function must have at least one parameter")
+		}
+		argQuery, err := b.processNode(root.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		qyOutput = &functionQuery{Input: argQuery, Func: notFunc}
+	case "name", "local-name", "namespace-uri":
+		inp := b.firstInput
+		if len(root.Args) > 1 {
+			return nil, fmt.Errorf("xpath: %s function must have at most one parameter", root.FuncName)
+		}
+		if len(root.Args) == 1 {
+			argQuery, err := b.processNode(root.Args[0])
+			if err != nil {
+				return nil, err
+			}
+			inp = argQuery
+		}
+		f := &functionQuery{Input: inp}
+		switch root.FuncName {
+		case "name":
+			f.Func = nameFunc
+		case "local-name":
+			f.Func = localNameFunc
+		case "namespace-uri":
+			f.Func = namespaceFunc
+		}
+		qyOutput = f
+	case "true", "false":
+		val := root.FuncName == "true"
+		qyOutput = &functionQuery{
+			Input: b.firstInput,
+			Func: func(_ query, _ iterator) interface{} {
+				return val
+			},
+		}
+	case "last":
+		qyOutput = &functionQuery{Input: b.firstInput, Func: lastFunc}
+	case "position":
+		qyOutput = &functionQuery{Input: b.firstInput, Func: positionFunc}
+	case "boolean", "number", "string":
+		inp := b.firstInput
+		if len(root.Args) > 1 {
+			return nil, fmt.Errorf("xpath: %s function must have at most one parameter", root.FuncName)
+		}
+		if len(root.Args) == 1 {
+			argQuery, err := b.processNode(root.Args[0])
+			if err != nil {
+				return nil, err
+			}
+			inp = argQuery
+		}
+		f := &functionQuery{Input: inp}
+		switch root.FuncName {
+		case "boolean":
+			f.Func = booleanFunc
+		case "string":
+			f.Func = stringFunc
+		case "number":
+			f.Func = numberFunc
+		}
+		qyOutput = f
+	case "count":
+		//if b.firstInput == nil {
+		//	return nil, errors.New("xpath: expression must evaluate to node-set")
+		//}
+		if len(root.Args) == 0 {
+			return nil, fmt.Errorf("xpath: count(node-sets) function must with have parameters node-sets")
+		}
+		argQuery, err := b.processNode(root.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		qyOutput = &functionQuery{Input: argQuery, Func: countFunc}
+	case "sum":
+		if len(root.Args) == 0 {
+			return nil, fmt.Errorf("xpath: sum(node-sets) function must with have parameters node-sets")
+		}
+		argQuery, err := b.processNode(root.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		qyOutput = &functionQuery{Input: argQuery, Func: sumFunc}
+	case "ceiling", "floor", "round":
+		if len(root.Args) == 0 {
+			return nil, fmt.Errorf("xpath: ceiling(node-sets) function must with have parameters node-sets")
+		}
+		argQuery, err := b.processNode(root.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		f := &functionQuery{Input: argQuery}
+		switch root.FuncName {
+		case "ceiling":
+			f.Func = ceilingFunc
+		case "floor":
+			f.Func = floorFunc
+		case "round":
+			f.Func = roundFunc
+		}
+		qyOutput = f
+	case "concat":
+		if len(root.Args) < 2 {
+			return nil, fmt.Errorf("xpath: concat() must have at least two arguments")
+		}
+		var args []query
+		for _, v := range root.Args {
+			q, err := b.processNode(v)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, q)
+		}
+		qyOutput = &functionQuery{Input: b.firstInput, Func: concatFunc(args...)}
+	default:
+		return nil, fmt.Errorf("not yet support this function %s()", root.FuncName)
+	}
+	return qyOutput, nil
+}
+
+func (b *builder) processOperatorNode(root *operatorNode) (query, error) {
+	left, err := b.processNode(root.Left)
+	if err != nil {
+		return nil, err
+	}
+	right, err := b.processNode(root.Right)
+	if err != nil {
+		return nil, err
+	}
+	var qyOutput query
+	switch root.Op {
+	case "+", "-", "div", "mod": // Numeric operator
+		var exprFunc func(interface{}, interface{}) interface{}
+		switch root.Op {
+		case "+":
+			exprFunc = plusFunc
+		case "-":
+			exprFunc = minusFunc
+		case "div":
+			exprFunc = divFunc
+		case "mod":
+			exprFunc = modFunc
+		}
+		qyOutput = &numericQuery{Left: left, Right: right, Do: exprFunc}
+	case "=", ">", ">=", "<", "<=", "!=":
+		var exprFunc func(iterator, interface{}, interface{}) interface{}
+		switch root.Op {
+		case "=":
+			exprFunc = eqFunc
+		case ">":
+			exprFunc = gtFunc
+		case ">=":
+			exprFunc = geFunc
+		case "<":
+			exprFunc = ltFunc
+		case "<=":
+			exprFunc = leFunc
+		case "!=":
+			exprFunc = neFunc
+		}
+		qyOutput = &logicalQuery{Left: left, Right: right, Do: exprFunc}
+	case "or", "and":
+		isOr := false
+		if root.Op == "or" {
+			isOr = true
+		}
+		qyOutput = &booleanQuery{Left: left, Right: right, IsOr: isOr}
+	case "|":
+		qyOutput = &unionQuery{Left: left, Right: right}
+	}
+	return qyOutput, nil
+}
+
+func (b *builder) processNode(root node) (q query, err error) {
+	if b.depth = b.depth + 1; b.depth > 1024 {
+		err = errors.New("the xpath expressions is too complex")
+		return
+	}
+
+	switch root.Type() {
+	case nodeConstantOperand:
+		n := root.(*operandNode)
+		q = &constantQuery{Val: n.Val}
+	case nodeRoot:
+		q = &contextQuery{Root: true}
+	case nodeAxis:
+		q, err = b.processAxisNode(root.(*axisNode))
+		b.firstInput = q
+	case nodeFilter:
+		q, err = b.processFilterNode(root.(*filterNode))
+	case nodeFunction:
+		q, err = b.processFunctionNode(root.(*functionNode))
+	case nodeOperator:
+		q, err = b.processOperatorNode(root.(*operatorNode))
+	}
+	return
+}
+
+// build builds a specified XPath expressions expr.
+func build(expr string) (q query, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			switch x := e.(type) {
+			case string:
+				err = errors.New(x)
+			case error:
+				err = x
+			default:
+				err = errors.New("unknown panic")
+			}
+		}
+	}()
+	root := parse(expr)
+	b := &builder{}
+	return b.processNode(root)
+}

--- a/vendor/github.com/antchfx/xpath/func.go
+++ b/vendor/github.com/antchfx/xpath/func.go
@@ -1,0 +1,469 @@
+package xpath
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// The XPath function list.
+
+func predicate(q query) func(NodeNavigator) bool {
+	type Predicater interface {
+		Test(NodeNavigator) bool
+	}
+	if p, ok := q.(Predicater); ok {
+		return p.Test
+	}
+	return func(NodeNavigator) bool { return true }
+}
+
+// positionFunc is a XPath Node Set functions position().
+func positionFunc(q query, t iterator) interface{} {
+	var (
+		count = 1
+		node  = t.Current()
+	)
+	test := predicate(q)
+	for node.MoveToPrevious() {
+		if test(node) {
+			count++
+		}
+	}
+	return float64(count)
+}
+
+// lastFunc is a XPath Node Set functions last().
+func lastFunc(q query, t iterator) interface{} {
+	var (
+		count = 0
+		node  = t.Current()
+	)
+	node.MoveToFirst()
+	test := predicate(q)
+	for {
+		if test(node) {
+			count++
+		}
+		if !node.MoveToNext() {
+			break
+		}
+	}
+	return float64(count)
+}
+
+// countFunc is a XPath Node Set functions count(node-set).
+func countFunc(q query, t iterator) interface{} {
+	var count = 0
+	test := predicate(q)
+	switch typ := q.Evaluate(t).(type) {
+	case query:
+		for node := typ.Select(t); node != nil; node = typ.Select(t) {
+			if test(node) {
+				count++
+			}
+		}
+	}
+	return float64(count)
+}
+
+// sumFunc is a XPath Node Set functions sum(node-set).
+func sumFunc(q query, t iterator) interface{} {
+	var sum float64
+	switch typ := q.Evaluate(t).(type) {
+	case query:
+		for node := typ.Select(t); node != nil; node = typ.Select(t) {
+			if v, err := strconv.ParseFloat(node.Value(), 64); err == nil {
+				sum += v
+			}
+		}
+	case float64:
+		sum = typ
+	case string:
+		v, err := strconv.ParseFloat(typ, 64)
+		if err != nil {
+			panic(errors.New("sum() function argument type must be a node-set or number"))
+		}
+		sum = v
+	}
+	return sum
+}
+
+func asNumber(t iterator, o interface{}) float64 {
+	switch typ := o.(type) {
+	case query:
+		node := typ.Select(t)
+		if node == nil {
+			return float64(0)
+		}
+		if v, err := strconv.ParseFloat(node.Value(), 64); err == nil {
+			return v
+		}
+	case float64:
+		return typ
+	case string:
+		v, err := strconv.ParseFloat(typ, 64)
+		if err != nil {
+			panic(errors.New("ceiling() function argument type must be a node-set or number"))
+		}
+		return v
+	}
+	return 0
+}
+
+// ceilingFunc is a XPath Node Set functions ceiling(node-set).
+func ceilingFunc(q query, t iterator) interface{} {
+	val := asNumber(t, q.Evaluate(t))
+	return math.Ceil(val)
+}
+
+// floorFunc is a XPath Node Set functions floor(node-set).
+func floorFunc(q query, t iterator) interface{} {
+	val := asNumber(t, q.Evaluate(t))
+	return math.Floor(val)
+}
+
+// roundFunc is a XPath Node Set functions round(node-set).
+func roundFunc(q query, t iterator) interface{} {
+	val := asNumber(t, q.Evaluate(t))
+	//return math.Round(val)
+	return round(val)
+}
+
+// nameFunc is a XPath functions name([node-set]).
+func nameFunc(q query, t iterator) interface{} {
+	v := q.Select(t)
+	if v == nil {
+		return ""
+	}
+	ns := v.Prefix()
+	if ns == "" {
+		return v.LocalName()
+	}
+	return ns + ":" + v.LocalName()
+}
+
+// localNameFunc is a XPath functions local-name([node-set]).
+func localNameFunc(q query, t iterator) interface{} {
+	v := q.Select(t)
+	if v == nil {
+		return ""
+	}
+	return v.LocalName()
+}
+
+// namespaceFunc is a XPath functions namespace-uri([node-set]).
+func namespaceFunc(q query, t iterator) interface{} {
+	v := q.Select(t)
+	if v == nil {
+		return ""
+	}
+	return v.Prefix()
+}
+
+func asBool(t iterator, v interface{}) bool {
+	switch v := v.(type) {
+	case nil:
+		return false
+	case *NodeIterator:
+		return v.MoveNext()
+	case bool:
+		return bool(v)
+	case float64:
+		return v != 0
+	case string:
+		return v != ""
+	case query:
+		return v.Select(t) != nil
+	default:
+		panic(fmt.Errorf("unexpected type: %T", v))
+	}
+}
+
+func asString(t iterator, v interface{}) string {
+	switch v := v.(type) {
+	case nil:
+		return ""
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case float64:
+		return strconv.FormatFloat(v, 'g', -1, 64)
+	case string:
+		return v
+	default:
+		panic(fmt.Errorf("unexpected type: %T", v))
+	}
+}
+
+// booleanFunc is a XPath functions boolean([node-set]).
+func booleanFunc(q query, t iterator) interface{} {
+	v := q.Evaluate(t)
+	return asBool(t, v)
+}
+
+// numberFunc is a XPath functions number([node-set]).
+func numberFunc(q query, t iterator) interface{} {
+	v := q.Evaluate(t)
+	return asNumber(t, v)
+}
+
+// stringFunc is a XPath functions string([node-set]).
+func stringFunc(q query, t iterator) interface{} {
+	v := q.Evaluate(t)
+	return asString(t, v)
+}
+
+// startwithFunc is a XPath functions starts-with(string, string).
+func startwithFunc(arg1, arg2 query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		var (
+			m, n string
+			ok   bool
+		)
+		switch typ := arg1.Evaluate(t).(type) {
+		case string:
+			m = typ
+		case query:
+			node := typ.Select(t)
+			if node == nil {
+				return false
+			}
+			m = node.Value()
+		default:
+			panic(errors.New("starts-with() function argument type must be string"))
+		}
+		n, ok = arg2.Evaluate(t).(string)
+		if !ok {
+			panic(errors.New("starts-with() function argument type must be string"))
+		}
+		return strings.HasPrefix(m, n)
+	}
+}
+
+// endwithFunc is a XPath functions ends-with(string, string).
+func endwithFunc(arg1, arg2 query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		var (
+			m, n string
+			ok   bool
+		)
+		switch typ := arg1.Evaluate(t).(type) {
+		case string:
+			m = typ
+		case query:
+			node := typ.Select(t)
+			if node == nil {
+				return false
+			}
+			m = node.Value()
+		default:
+			panic(errors.New("ends-with() function argument type must be string"))
+		}
+		n, ok = arg2.Evaluate(t).(string)
+		if !ok {
+			panic(errors.New("ends-with() function argument type must be string"))
+		}
+		return strings.HasSuffix(m, n)
+	}
+}
+
+// containsFunc is a XPath functions contains(string or @attr, string).
+func containsFunc(arg1, arg2 query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		var (
+			m, n string
+			ok   bool
+		)
+
+		switch typ := arg1.Evaluate(t).(type) {
+		case string:
+			m = typ
+		case query:
+			node := typ.Select(t)
+			if node == nil {
+				return false
+			}
+			m = node.Value()
+		default:
+			panic(errors.New("contains() function argument type must be string"))
+		}
+
+		n, ok = arg2.Evaluate(t).(string)
+		if !ok {
+			panic(errors.New("contains() function argument type must be string"))
+		}
+
+		return strings.Contains(m, n)
+	}
+}
+
+// normalizespaceFunc is XPath functions normalize-space(string?)
+func normalizespaceFunc(q query, t iterator) interface{} {
+	var m string
+	switch typ := q.Evaluate(t).(type) {
+	case string:
+		m = typ
+	case query:
+		node := typ.Select(t)
+		if node == nil {
+			return false
+		}
+		m = node.Value()
+	}
+	return strings.TrimSpace(m)
+}
+
+// substringFunc is XPath functions substring function returns a part of a given string.
+func substringFunc(arg1, arg2, arg3 query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		var m string
+		switch typ := arg1.Evaluate(t).(type) {
+		case string:
+			m = typ
+		case query:
+			node := typ.Select(t)
+			if node == nil {
+				return ""
+			}
+			m = node.Value()
+		}
+
+		var start, length float64
+		var ok bool
+
+		if start, ok = arg2.Evaluate(t).(float64); !ok {
+			panic(errors.New("substring() function first argument type must be int"))
+		} else if start < 1 {
+			panic(errors.New("substring() function first argument type must be >= 1"))
+		}
+		start--
+		if arg3 != nil {
+			if length, ok = arg3.Evaluate(t).(float64); !ok {
+				panic(errors.New("substring() function second argument type must be int"))
+			}
+		}
+		if (len(m) - int(start)) < int(length) {
+			panic(errors.New("substring() function start and length argument out of range"))
+		}
+		if length > 0 {
+			return m[int(start):int(length+start)]
+		}
+		return m[int(start):]
+	}
+}
+
+// substringIndFunc is XPath functions substring-before/substring-after function returns a part of a given string.
+func substringIndFunc(arg1, arg2 query, after bool) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		var str string
+		switch v := arg1.Evaluate(t).(type) {
+		case string:
+			str = v
+		case query:
+			node := v.Select(t)
+			if node == nil {
+				return ""
+			}
+			str = node.Value()
+		}
+		var word string
+		switch v := arg2.Evaluate(t).(type) {
+		case string:
+			word = v
+		case query:
+			node := v.Select(t)
+			if node == nil {
+				return ""
+			}
+			word = node.Value()
+		}
+		if word == "" {
+			return ""
+		}
+
+		i := strings.Index(str, word)
+		if i < 0 {
+			return ""
+		}
+		if after {
+			return str[i+len(word):]
+		}
+		return str[:i]
+	}
+}
+
+// stringLengthFunc is XPATH string-length( [string] ) function that returns a number
+// equal to the number of characters in a given string.
+func stringLengthFunc(arg1 query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		switch v := arg1.Evaluate(t).(type) {
+		case string:
+			return float64(len(v))
+		case query:
+			node := v.Select(t)
+			if node == nil {
+				break
+			}
+			return float64(len(node.Value()))
+		}
+		return float64(0)
+	}
+}
+
+// translateFunc is XPath functions translate() function returns a replaced string.
+func translateFunc(arg1, arg2, arg3 query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		str := asString(t, arg1.Evaluate(t))
+		src := asString(t, arg2.Evaluate(t))
+		dst := asString(t, arg3.Evaluate(t))
+
+		var replace []string
+		for i, s := range src {
+			d := ""
+			if i < len(dst) {
+				d = string(dst[i])
+			}
+			replace = append(replace, string(s), d)
+		}
+		return strings.NewReplacer(replace...).Replace(str)
+	}
+}
+
+// notFunc is XPATH functions not(expression) function operation.
+func notFunc(q query, t iterator) interface{} {
+	switch v := q.Evaluate(t).(type) {
+	case bool:
+		return !v
+	case query:
+		node := v.Select(t)
+		return node == nil
+	default:
+		return false
+	}
+}
+
+// concatFunc is the concat function concatenates two or more
+// strings and returns the resulting string.
+// concat( string1 , string2 [, stringn]* )
+func concatFunc(args ...query) func(query, iterator) interface{} {
+	return func(q query, t iterator) interface{} {
+		var a []string
+		for _, v := range args {
+			switch v := v.Evaluate(t).(type) {
+			case string:
+				a = append(a, v)
+			case query:
+				node := v.Select(t)
+				if node != nil {
+					a = append(a, node.Value())
+				}
+			}
+		}
+		return strings.Join(a, "")
+	}
+}

--- a/vendor/github.com/antchfx/xpath/func_go110.go
+++ b/vendor/github.com/antchfx/xpath/func_go110.go
@@ -1,0 +1,9 @@
+// +build go1.10
+
+package xpath
+
+import "math"
+
+func round(f float64) int {
+	return int(math.Round(f))
+}

--- a/vendor/github.com/antchfx/xpath/func_pre_go110.go
+++ b/vendor/github.com/antchfx/xpath/func_pre_go110.go
@@ -1,0 +1,15 @@
+// +build !go1.10
+
+package xpath
+
+import "math"
+
+// math.Round() is supported by Go 1.10+,
+// This method just compatible for version <1.10.
+// https://github.com/golang/go/issues/20100
+func round(f float64) int {
+	if math.Abs(f) < 0.5 {
+		return 0
+	}
+	return int(f + math.Copysign(0.5, f))
+}

--- a/vendor/github.com/antchfx/xpath/operator.go
+++ b/vendor/github.com/antchfx/xpath/operator.go
@@ -1,0 +1,295 @@
+package xpath
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+// The XPath number operator function list.
+
+// valueType is a return value type.
+type valueType int
+
+const (
+	booleanType valueType = iota
+	numberType
+	stringType
+	nodeSetType
+)
+
+func getValueType(i interface{}) valueType {
+	v := reflect.ValueOf(i)
+	switch v.Kind() {
+	case reflect.Float64:
+		return numberType
+	case reflect.String:
+		return stringType
+	case reflect.Bool:
+		return booleanType
+	default:
+		if _, ok := i.(query); ok {
+			return nodeSetType
+		}
+	}
+	panic(fmt.Errorf("xpath unknown value type: %v", v.Kind()))
+}
+
+type logical func(iterator, string, interface{}, interface{}) bool
+
+var logicalFuncs = [][]logical{
+	{cmpBooleanBoolean, nil, nil, nil},
+	{nil, cmpNumericNumeric, cmpNumericString, cmpNumericNodeSet},
+	{nil, cmpStringNumeric, cmpStringString, cmpStringNodeSet},
+	{nil, cmpNodeSetNumeric, cmpNodeSetString, cmpNodeSetNodeSet},
+}
+
+// number vs number
+func cmpNumberNumberF(op string, a, b float64) bool {
+	switch op {
+	case "=":
+		return a == b
+	case ">":
+		return a > b
+	case "<":
+		return a < b
+	case ">=":
+		return a >= b
+	case "<=":
+		return a <= b
+	case "!=":
+		return a != b
+	}
+	return false
+}
+
+// string vs string
+func cmpStringStringF(op string, a, b string) bool {
+	switch op {
+	case "=":
+		return a == b
+	case ">":
+		return a > b
+	case "<":
+		return a < b
+	case ">=":
+		return a >= b
+	case "<=":
+		return a <= b
+	case "!=":
+		return a != b
+	}
+	return false
+}
+
+func cmpBooleanBooleanF(op string, a, b bool) bool {
+	switch op {
+	case "or":
+		return a || b
+	case "and":
+		return a && b
+	}
+	return false
+}
+
+func cmpNumericNumeric(t iterator, op string, m, n interface{}) bool {
+	a := m.(float64)
+	b := n.(float64)
+	return cmpNumberNumberF(op, a, b)
+}
+
+func cmpNumericString(t iterator, op string, m, n interface{}) bool {
+	a := m.(float64)
+	b := n.(string)
+	num, err := strconv.ParseFloat(b, 64)
+	if err != nil {
+		panic(err)
+	}
+	return cmpNumberNumberF(op, a, num)
+}
+
+func cmpNumericNodeSet(t iterator, op string, m, n interface{}) bool {
+	a := m.(float64)
+	b := n.(query)
+
+	for {
+		node := b.Select(t)
+		if node == nil {
+			break
+		}
+		num, err := strconv.ParseFloat(node.Value(), 64)
+		if err != nil {
+			panic(err)
+		}
+		if cmpNumberNumberF(op, a, num) {
+			return true
+		}
+	}
+	return false
+}
+
+func cmpNodeSetNumeric(t iterator, op string, m, n interface{}) bool {
+	a := m.(query)
+	b := n.(float64)
+	for {
+		node := a.Select(t)
+		if node == nil {
+			break
+		}
+		num, err := strconv.ParseFloat(node.Value(), 64)
+		if err != nil {
+			panic(err)
+		}
+		if cmpNumberNumberF(op, num, b) {
+			return true
+		}
+	}
+	return false
+}
+
+func cmpNodeSetString(t iterator, op string, m, n interface{}) bool {
+	a := m.(query)
+	b := n.(string)
+	for {
+		node := a.Select(t)
+		if node == nil {
+			break
+		}
+		if cmpStringStringF(op, b, node.Value()) {
+			return true
+		}
+	}
+	return false
+}
+
+func cmpNodeSetNodeSet(t iterator, op string, m, n interface{}) bool {
+	return false
+}
+
+func cmpStringNumeric(t iterator, op string, m, n interface{}) bool {
+	a := m.(string)
+	b := n.(float64)
+	num, err := strconv.ParseFloat(a, 64)
+	if err != nil {
+		panic(err)
+	}
+	return cmpNumberNumberF(op, b, num)
+}
+
+func cmpStringString(t iterator, op string, m, n interface{}) bool {
+	a := m.(string)
+	b := n.(string)
+	return cmpStringStringF(op, a, b)
+}
+
+func cmpStringNodeSet(t iterator, op string, m, n interface{}) bool {
+	a := m.(string)
+	b := n.(query)
+	for {
+		node := b.Select(t)
+		if node == nil {
+			break
+		}
+		if cmpStringStringF(op, a, node.Value()) {
+			return true
+		}
+	}
+	return false
+}
+
+func cmpBooleanBoolean(t iterator, op string, m, n interface{}) bool {
+	a := m.(bool)
+	b := n.(bool)
+	return cmpBooleanBooleanF(op, a, b)
+}
+
+// eqFunc is an `=` operator.
+func eqFunc(t iterator, m, n interface{}) interface{} {
+	t1 := getValueType(m)
+	t2 := getValueType(n)
+	return logicalFuncs[t1][t2](t, "=", m, n)
+}
+
+// gtFunc is an `>` operator.
+func gtFunc(t iterator, m, n interface{}) interface{} {
+	t1 := getValueType(m)
+	t2 := getValueType(n)
+	return logicalFuncs[t1][t2](t, ">", m, n)
+}
+
+// geFunc is an `>=` operator.
+func geFunc(t iterator, m, n interface{}) interface{} {
+	t1 := getValueType(m)
+	t2 := getValueType(n)
+	return logicalFuncs[t1][t2](t, ">=", m, n)
+}
+
+// ltFunc is an `<` operator.
+func ltFunc(t iterator, m, n interface{}) interface{} {
+	t1 := getValueType(m)
+	t2 := getValueType(n)
+	return logicalFuncs[t1][t2](t, "<", m, n)
+}
+
+// leFunc is an `<=` operator.
+func leFunc(t iterator, m, n interface{}) interface{} {
+	t1 := getValueType(m)
+	t2 := getValueType(n)
+	return logicalFuncs[t1][t2](t, "<=", m, n)
+}
+
+// neFunc is an `!=` operator.
+func neFunc(t iterator, m, n interface{}) interface{} {
+	t1 := getValueType(m)
+	t2 := getValueType(n)
+	return logicalFuncs[t1][t2](t, "!=", m, n)
+}
+
+// orFunc is an `or` operator.
+var orFunc = func(t iterator, m, n interface{}) interface{} {
+	t1 := getValueType(m)
+	t2 := getValueType(n)
+	return logicalFuncs[t1][t2](t, "or", m, n)
+}
+
+func numericExpr(m, n interface{}, cb func(float64, float64) float64) float64 {
+	typ := reflect.TypeOf(float64(0))
+	a := reflect.ValueOf(m).Convert(typ)
+	b := reflect.ValueOf(n).Convert(typ)
+	return cb(a.Float(), b.Float())
+}
+
+// plusFunc is an `+` operator.
+var plusFunc = func(m, n interface{}) interface{} {
+	return numericExpr(m, n, func(a, b float64) float64 {
+		return a + b
+	})
+}
+
+// minusFunc is an `-` operator.
+var minusFunc = func(m, n interface{}) interface{} {
+	return numericExpr(m, n, func(a, b float64) float64 {
+		return a - b
+	})
+}
+
+// mulFunc is an `*` operator.
+var mulFunc = func(m, n interface{}) interface{} {
+	return numericExpr(m, n, func(a, b float64) float64 {
+		return a * b
+	})
+}
+
+// divFunc is an `DIV` operator.
+var divFunc = func(m, n interface{}) interface{} {
+	return numericExpr(m, n, func(a, b float64) float64 {
+		return a / b
+	})
+}
+
+// modFunc is an 'MOD' operator.
+var modFunc = func(m, n interface{}) interface{} {
+	return numericExpr(m, n, func(a, b float64) float64 {
+		return float64(int(a) % int(b))
+	})
+}

--- a/vendor/github.com/antchfx/xpath/parse.go
+++ b/vendor/github.com/antchfx/xpath/parse.go
@@ -1,0 +1,1164 @@
+package xpath
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"unicode"
+)
+
+// A XPath expression token type.
+type itemType int
+
+const (
+	itemComma      itemType = iota // ','
+	itemSlash                      // '/'
+	itemAt                         // '@'
+	itemDot                        // '.'
+	itemLParens                    // '('
+	itemRParens                    // ')'
+	itemLBracket                   // '['
+	itemRBracket                   // ']'
+	itemStar                       // '*'
+	itemPlus                       // '+'
+	itemMinus                      // '-'
+	itemEq                         // '='
+	itemLt                         // '<'
+	itemGt                         // '>'
+	itemBang                       // '!'
+	itemDollar                     // '$'
+	itemApos                       // '\''
+	itemQuote                      // '"'
+	itemUnion                      // '|'
+	itemNe                         // '!='
+	itemLe                         // '<='
+	itemGe                         // '>='
+	itemAnd                        // '&&'
+	itemOr                         // '||'
+	itemDotDot                     // '..'
+	itemSlashSlash                 // '//'
+	itemName                       // XML Name
+	itemString                     // Quoted string constant
+	itemNumber                     // Number constant
+	itemAxe                        // Axe (like child::)
+	itemEof                        // END
+)
+
+// A node is an XPath node in the parse tree.
+type node interface {
+	Type() nodeType
+}
+
+// nodeType identifies the type of a parse tree node.
+type nodeType int
+
+func (t nodeType) Type() nodeType {
+	return t
+}
+
+const (
+	nodeRoot nodeType = iota
+	nodeAxis
+	nodeFilter
+	nodeFunction
+	nodeOperator
+	nodeVariable
+	nodeConstantOperand
+)
+
+type parser struct {
+	r *scanner
+	d int
+}
+
+// newOperatorNode returns new operator node OperatorNode.
+func newOperatorNode(op string, left, right node) node {
+	return &operatorNode{nodeType: nodeOperator, Op: op, Left: left, Right: right}
+}
+
+// newOperand returns new constant operand node OperandNode.
+func newOperandNode(v interface{}) node {
+	return &operandNode{nodeType: nodeConstantOperand, Val: v}
+}
+
+// newAxisNode returns new axis node AxisNode.
+func newAxisNode(axeTyp, localName, prefix, prop string, n node) node {
+	return &axisNode{
+		nodeType:  nodeAxis,
+		LocalName: localName,
+		Prefix:    prefix,
+		AxeType:   axeTyp,
+		Prop:      prop,
+		Input:     n,
+	}
+}
+
+// newVariableNode returns new variable node VariableNode.
+func newVariableNode(prefix, name string) node {
+	return &variableNode{nodeType: nodeVariable, Name: name, Prefix: prefix}
+}
+
+// newFilterNode returns a new filter node FilterNode.
+func newFilterNode(n, m node) node {
+	return &filterNode{nodeType: nodeFilter, Input: n, Condition: m}
+}
+
+// newRootNode returns a root node.
+func newRootNode(s string) node {
+	return &rootNode{nodeType: nodeRoot, slash: s}
+}
+
+// newFunctionNode returns function call node.
+func newFunctionNode(name, prefix string, args []node) node {
+	return &functionNode{nodeType: nodeFunction, Prefix: prefix, FuncName: name, Args: args}
+}
+
+// testOp reports whether current item name is an operand op.
+func testOp(r *scanner, op string) bool {
+	return r.typ == itemName && r.prefix == "" && r.name == op
+}
+
+func isPrimaryExpr(r *scanner) bool {
+	switch r.typ {
+	case itemString, itemNumber, itemDollar, itemLParens:
+		return true
+	case itemName:
+		return r.canBeFunc && !isNodeType(r)
+	}
+	return false
+}
+
+func isNodeType(r *scanner) bool {
+	switch r.name {
+	case "node", "text", "processing-instruction", "comment":
+		return r.prefix == ""
+	}
+	return false
+}
+
+func isStep(item itemType) bool {
+	switch item {
+	case itemDot, itemDotDot, itemAt, itemAxe, itemStar, itemName:
+		return true
+	}
+	return false
+}
+
+func checkItem(r *scanner, typ itemType) {
+	if r.typ != typ {
+		panic(fmt.Sprintf("%s has an invalid token", r.text))
+	}
+}
+
+// parseExpression parsing the expression with input node n.
+func (p *parser) parseExpression(n node) node {
+	if p.d = p.d + 1; p.d > 200 {
+		panic("the xpath query is too complex(depth > 200)")
+	}
+	n = p.parseOrExpr(n)
+	p.d--
+	return n
+}
+
+// next scanning next item on forward.
+func (p *parser) next() bool {
+	return p.r.nextItem()
+}
+
+func (p *parser) skipItem(typ itemType) {
+	checkItem(p.r, typ)
+	p.next()
+}
+
+// OrExpr ::= AndExpr | OrExpr 'or' AndExpr
+func (p *parser) parseOrExpr(n node) node {
+	opnd := p.parseAndExpr(n)
+	for {
+		if !testOp(p.r, "or") {
+			break
+		}
+		p.next()
+		opnd = newOperatorNode("or", opnd, p.parseAndExpr(n))
+	}
+	return opnd
+}
+
+// AndExpr ::= EqualityExpr	| AndExpr 'and' EqualityExpr
+func (p *parser) parseAndExpr(n node) node {
+	opnd := p.parseEqualityExpr(n)
+	for {
+		if !testOp(p.r, "and") {
+			break
+		}
+		p.next()
+		opnd = newOperatorNode("and", opnd, p.parseEqualityExpr(n))
+	}
+	return opnd
+}
+
+// EqualityExpr ::= RelationalExpr | EqualityExpr '=' RelationalExpr | EqualityExpr '!=' RelationalExpr
+func (p *parser) parseEqualityExpr(n node) node {
+	opnd := p.parseRelationalExpr(n)
+Loop:
+	for {
+		var op string
+		switch p.r.typ {
+		case itemEq:
+			op = "="
+		case itemNe:
+			op = "!="
+		default:
+			break Loop
+		}
+		p.next()
+		opnd = newOperatorNode(op, opnd, p.parseRelationalExpr(n))
+	}
+	return opnd
+}
+
+// RelationalExpr ::= AdditiveExpr	| RelationalExpr '<' AdditiveExpr | RelationalExpr '>' AdditiveExpr
+//					| RelationalExpr '<=' AdditiveExpr
+//					| RelationalExpr '>=' AdditiveExpr
+func (p *parser) parseRelationalExpr(n node) node {
+	opnd := p.parseAdditiveExpr(n)
+Loop:
+	for {
+		var op string
+		switch p.r.typ {
+		case itemLt:
+			op = "<"
+		case itemGt:
+			op = ">"
+		case itemLe:
+			op = "<="
+		case itemGe:
+			op = ">="
+		default:
+			break Loop
+		}
+		p.next()
+		opnd = newOperatorNode(op, opnd, p.parseAdditiveExpr(n))
+	}
+	return opnd
+}
+
+// AdditiveExpr	::= MultiplicativeExpr	| AdditiveExpr '+' MultiplicativeExpr | AdditiveExpr '-' MultiplicativeExpr
+func (p *parser) parseAdditiveExpr(n node) node {
+	opnd := p.parseMultiplicativeExpr(n)
+Loop:
+	for {
+		var op string
+		switch p.r.typ {
+		case itemPlus:
+			op = "+"
+		case itemMinus:
+			op = "-"
+		default:
+			break Loop
+		}
+		p.next()
+		opnd = newOperatorNode(op, opnd, p.parseMultiplicativeExpr(n))
+	}
+	return opnd
+}
+
+// MultiplicativeExpr ::= UnaryExpr	| MultiplicativeExpr MultiplyOperator(*) UnaryExpr
+//						| MultiplicativeExpr 'div' UnaryExpr | MultiplicativeExpr 'mod' UnaryExpr
+func (p *parser) parseMultiplicativeExpr(n node) node {
+	opnd := p.parseUnaryExpr(n)
+Loop:
+	for {
+		var op string
+		if p.r.typ == itemStar {
+			op = "*"
+		} else if testOp(p.r, "div") || testOp(p.r, "mod") {
+			op = p.r.name
+		} else {
+			break Loop
+		}
+		p.next()
+		opnd = newOperatorNode(op, opnd, p.parseUnaryExpr(n))
+	}
+	return opnd
+}
+
+// UnaryExpr ::= UnionExpr | '-' UnaryExpr
+func (p *parser) parseUnaryExpr(n node) node {
+	minus := false
+	// ignore '-' sequence
+	for p.r.typ == itemMinus {
+		p.next()
+		minus = !minus
+	}
+	opnd := p.parseUnionExpr(n)
+	if minus {
+		opnd = newOperatorNode("*", opnd, newOperandNode(float64(-1)))
+	}
+	return opnd
+}
+
+// 	UnionExpr ::= PathExpr | UnionExpr '|' PathExpr
+func (p *parser) parseUnionExpr(n node) node {
+	opnd := p.parsePathExpr(n)
+Loop:
+	for {
+		if p.r.typ != itemUnion {
+			break Loop
+		}
+		p.next()
+		opnd2 := p.parsePathExpr(n)
+		// Checking the node type that must be is node set type?
+		opnd = newOperatorNode("|", opnd, opnd2)
+	}
+	return opnd
+}
+
+// PathExpr ::= LocationPath | FilterExpr | FilterExpr '/' RelativeLocationPath	| FilterExpr '//' RelativeLocationPath
+func (p *parser) parsePathExpr(n node) node {
+	var opnd node
+	if isPrimaryExpr(p.r) {
+		opnd = p.parseFilterExpr(n)
+		switch p.r.typ {
+		case itemSlash:
+			p.next()
+			opnd = p.parseRelativeLocationPath(opnd)
+		case itemSlashSlash:
+			p.next()
+			opnd = p.parseRelativeLocationPath(newAxisNode("descendant-or-self", "", "", "", opnd))
+		}
+	} else {
+		opnd = p.parseLocationPath(nil)
+	}
+	return opnd
+}
+
+// FilterExpr ::= PrimaryExpr | FilterExpr Predicate
+func (p *parser) parseFilterExpr(n node) node {
+	opnd := p.parsePrimaryExpr(n)
+	if p.r.typ == itemLBracket {
+		opnd = newFilterNode(opnd, p.parsePredicate(opnd))
+	}
+	return opnd
+}
+
+// 	Predicate ::=  '[' PredicateExpr ']'
+func (p *parser) parsePredicate(n node) node {
+	p.skipItem(itemLBracket)
+	opnd := p.parseExpression(n)
+	p.skipItem(itemRBracket)
+	return opnd
+}
+
+// LocationPath ::= RelativeLocationPath | AbsoluteLocationPath
+func (p *parser) parseLocationPath(n node) (opnd node) {
+	switch p.r.typ {
+	case itemSlash:
+		p.next()
+		opnd = newRootNode("/")
+		if isStep(p.r.typ) {
+			opnd = p.parseRelativeLocationPath(opnd) // ?? child:: or self ??
+		}
+	case itemSlashSlash:
+		p.next()
+		opnd = newRootNode("//")
+		opnd = p.parseRelativeLocationPath(newAxisNode("descendant-or-self", "", "", "", opnd))
+	default:
+		opnd = p.parseRelativeLocationPath(n)
+	}
+	return opnd
+}
+
+// RelativeLocationPath	 ::= Step | RelativeLocationPath '/' Step | AbbreviatedRelativeLocationPath
+func (p *parser) parseRelativeLocationPath(n node) node {
+	opnd := n
+Loop:
+	for {
+		opnd = p.parseStep(opnd)
+		switch p.r.typ {
+		case itemSlashSlash:
+			p.next()
+			opnd = newAxisNode("descendant-or-self", "", "", "", opnd)
+		case itemSlash:
+			p.next()
+		default:
+			break Loop
+		}
+	}
+	return opnd
+}
+
+// Step	::= AxisSpecifier NodeTest Predicate* | AbbreviatedStep
+func (p *parser) parseStep(n node) node {
+	axeTyp := "child" // default axes value.
+	if p.r.typ == itemDot || p.r.typ == itemDotDot {
+		if p.r.typ == itemDot {
+			axeTyp = "self"
+		} else {
+			axeTyp = "parent"
+		}
+		p.next()
+		return newAxisNode(axeTyp, "", "", "", n)
+	}
+	switch p.r.typ {
+	case itemAt:
+		p.next()
+		axeTyp = "attribute"
+	case itemAxe:
+		axeTyp = p.r.name
+		p.next()
+	}
+	opnd := p.parseNodeTest(n, axeTyp)
+	for p.r.typ == itemLBracket {
+		opnd = newFilterNode(opnd, p.parsePredicate(opnd))
+	}
+	return opnd
+}
+
+// 	NodeTest ::= NameTest | nodeType '(' ')' | 'processing-instruction' '(' Literal ')'
+func (p *parser) parseNodeTest(n node, axeTyp string) (opnd node) {
+	switch p.r.typ {
+	case itemName:
+		if p.r.canBeFunc && isNodeType(p.r) {
+			var prop string
+			switch p.r.name {
+			case "comment", "text", "processing-instruction", "node":
+				prop = p.r.name
+			}
+			var name string
+			p.next()
+			p.skipItem(itemLParens)
+			if prop == "processing-instruction" && p.r.typ != itemRParens {
+				checkItem(p.r, itemString)
+				name = p.r.strval
+				p.next()
+			}
+			p.skipItem(itemRParens)
+			opnd = newAxisNode(axeTyp, name, "", prop, n)
+		} else {
+			prefix := p.r.prefix
+			name := p.r.name
+			p.next()
+			if p.r.name == "*" {
+				name = ""
+			}
+			opnd = newAxisNode(axeTyp, name, prefix, "", n)
+		}
+	case itemStar:
+		opnd = newAxisNode(axeTyp, "", "", "", n)
+		p.next()
+	default:
+		panic("expression must evaluate to a node-set")
+	}
+	return opnd
+}
+
+// PrimaryExpr ::= VariableReference | '(' Expr ')'	| Literal | Number | FunctionCall
+func (p *parser) parsePrimaryExpr(n node) (opnd node) {
+	switch p.r.typ {
+	case itemString:
+		opnd = newOperandNode(p.r.strval)
+		p.next()
+	case itemNumber:
+		opnd = newOperandNode(p.r.numval)
+		p.next()
+	case itemDollar:
+		p.next()
+		checkItem(p.r, itemName)
+		opnd = newVariableNode(p.r.prefix, p.r.name)
+		p.next()
+	case itemLParens:
+		p.next()
+		opnd = p.parseExpression(n)
+		p.skipItem(itemRParens)
+	case itemName:
+		if p.r.canBeFunc && !isNodeType(p.r) {
+			opnd = p.parseMethod(nil)
+		}
+	}
+	return opnd
+}
+
+// FunctionCall	 ::=  FunctionName '(' ( Argument ( ',' Argument )* )? ')'
+func (p *parser) parseMethod(n node) node {
+	var args []node
+	name := p.r.name
+	prefix := p.r.prefix
+
+	p.skipItem(itemName)
+	p.skipItem(itemLParens)
+	if p.r.typ != itemRParens {
+		for {
+			args = append(args, p.parseExpression(n))
+			if p.r.typ == itemRParens {
+				break
+			}
+			p.skipItem(itemComma)
+		}
+	}
+	p.skipItem(itemRParens)
+	return newFunctionNode(name, prefix, args)
+}
+
+// Parse parsing the XPath express string expr and returns a tree node.
+func parse(expr string) node {
+	r := &scanner{text: expr}
+	r.nextChar()
+	r.nextItem()
+	p := &parser{r: r}
+	return p.parseExpression(nil)
+}
+
+// rootNode holds a top-level node of tree.
+type rootNode struct {
+	nodeType
+	slash string
+}
+
+func (r *rootNode) String() string {
+	return r.slash
+}
+
+// operatorNode holds two Nodes operator.
+type operatorNode struct {
+	nodeType
+	Op          string
+	Left, Right node
+}
+
+func (o *operatorNode) String() string {
+	return fmt.Sprintf("%v%s%v", o.Left, o.Op, o.Right)
+}
+
+// axisNode holds a location step.
+type axisNode struct {
+	nodeType
+	Input     node
+	Prop      string // node-test name.[comment|text|processing-instruction|node]
+	AxeType   string // name of the axes.[attribute|ancestor|child|....]
+	LocalName string // local part name of node.
+	Prefix    string // prefix name of node.
+}
+
+func (a *axisNode) String() string {
+	var b bytes.Buffer
+	if a.AxeType != "" {
+		b.Write([]byte(a.AxeType + "::"))
+	}
+	if a.Prefix != "" {
+		b.Write([]byte(a.Prefix + ":"))
+	}
+	b.Write([]byte(a.LocalName))
+	if a.Prop != "" {
+		b.Write([]byte("/" + a.Prop + "()"))
+	}
+	return b.String()
+}
+
+// operandNode holds a constant operand.
+type operandNode struct {
+	nodeType
+	Val interface{}
+}
+
+func (o *operandNode) String() string {
+	return fmt.Sprintf("%v", o.Val)
+}
+
+// filterNode holds a condition filter.
+type filterNode struct {
+	nodeType
+	Input, Condition node
+}
+
+func (f *filterNode) String() string {
+	return fmt.Sprintf("%s[%s]", f.Input, f.Condition)
+}
+
+// variableNode holds a variable.
+type variableNode struct {
+	nodeType
+	Name, Prefix string
+}
+
+func (v *variableNode) String() string {
+	if v.Prefix == "" {
+		return v.Name
+	}
+	return fmt.Sprintf("%s:%s", v.Prefix, v.Name)
+}
+
+// functionNode holds a function call.
+type functionNode struct {
+	nodeType
+	Args     []node
+	Prefix   string
+	FuncName string // function name
+}
+
+func (f *functionNode) String() string {
+	var b bytes.Buffer
+	// fun(arg1, ..., argn)
+	b.Write([]byte(f.FuncName))
+	b.Write([]byte("("))
+	for i, arg := range f.Args {
+		if i > 0 {
+			b.Write([]byte(","))
+		}
+		b.Write([]byte(fmt.Sprintf("%s", arg)))
+	}
+	b.Write([]byte(")"))
+	return b.String()
+}
+
+type scanner struct {
+	text, name, prefix string
+
+	pos       int
+	curr      rune
+	typ       itemType
+	strval    string  // text value at current pos
+	numval    float64 // number value at current pos
+	canBeFunc bool
+}
+
+func (s *scanner) nextChar() bool {
+	if s.pos >= len(s.text) {
+		s.curr = rune(0)
+		return false
+	}
+	s.curr = rune(s.text[s.pos])
+	s.pos += 1
+	return true
+}
+
+func (s *scanner) nextItem() bool {
+	s.skipSpace()
+	switch s.curr {
+	case 0:
+		s.typ = itemEof
+		return false
+	case ',', '@', '(', ')', '|', '*', '[', ']', '+', '-', '=', '#', '$':
+		s.typ = asItemType(s.curr)
+		s.nextChar()
+	case '<':
+		s.typ = itemLt
+		s.nextChar()
+		if s.curr == '=' {
+			s.typ = itemLe
+			s.nextChar()
+		}
+	case '>':
+		s.typ = itemGt
+		s.nextChar()
+		if s.curr == '=' {
+			s.typ = itemGe
+			s.nextChar()
+		}
+	case '!':
+		s.typ = itemBang
+		s.nextChar()
+		if s.curr == '=' {
+			s.typ = itemNe
+			s.nextChar()
+		}
+	case '.':
+		s.typ = itemDot
+		s.nextChar()
+		if s.curr == '.' {
+			s.typ = itemDotDot
+			s.nextChar()
+		} else if isDigit(s.curr) {
+			s.typ = itemNumber
+			s.numval = s.scanFraction()
+		}
+	case '/':
+		s.typ = itemSlash
+		s.nextChar()
+		if s.curr == '/' {
+			s.typ = itemSlashSlash
+			s.nextChar()
+		}
+	case '"', '\'':
+		s.typ = itemString
+		s.strval = s.scanString()
+	default:
+		if isDigit(s.curr) {
+			s.typ = itemNumber
+			s.numval = s.scanNumber()
+		} else if isName(s.curr) {
+			s.typ = itemName
+			s.name = s.scanName()
+			s.prefix = ""
+			// "foo:bar" is one itemem not three because it doesn't allow spaces in between
+			// We should distinct it from "foo::" and need process "foo ::" as well
+			if s.curr == ':' {
+				s.nextChar()
+				// can be "foo:bar" or "foo::"
+				if s.curr == ':' {
+					// "foo::"
+					s.nextChar()
+					s.typ = itemAxe
+				} else { // "foo:*", "foo:bar" or "foo: "
+					s.prefix = s.name
+					if s.curr == '*' {
+						s.nextChar()
+						s.name = "*"
+					} else if isName(s.curr) {
+						s.name = s.scanName()
+					} else {
+						panic(fmt.Sprintf("%s has an invalid qualified name.", s.text))
+					}
+				}
+			} else {
+				s.skipSpace()
+				if s.curr == ':' {
+					s.nextChar()
+					// it can be "foo ::" or just "foo :"
+					if s.curr == ':' {
+						s.nextChar()
+						s.typ = itemAxe
+					} else {
+						panic(fmt.Sprintf("%s has an invalid qualified name.", s.text))
+					}
+				}
+			}
+			s.skipSpace()
+			s.canBeFunc = s.curr == '('
+		} else {
+			panic(fmt.Sprintf("%s has an invalid token.", s.text))
+		}
+	}
+	return true
+}
+
+func (s *scanner) skipSpace() {
+Loop:
+	for {
+		if !unicode.IsSpace(s.curr) || !s.nextChar() {
+			break Loop
+		}
+	}
+}
+
+func (s *scanner) scanFraction() float64 {
+	var (
+		i = s.pos - 2
+		c = 1 // '.'
+	)
+	for isDigit(s.curr) {
+		s.nextChar()
+		c++
+	}
+	v, err := strconv.ParseFloat(s.text[i:i+c], 64)
+	if err != nil {
+		panic(fmt.Errorf("xpath: scanFraction parse float got error: %v", err))
+	}
+	return v
+}
+
+func (s *scanner) scanNumber() float64 {
+	var (
+		c int
+		i = s.pos - 1
+	)
+	for isDigit(s.curr) {
+		s.nextChar()
+		c++
+	}
+	if s.curr == '.' {
+		s.nextChar()
+		c++
+		for isDigit(s.curr) {
+			s.nextChar()
+			c++
+		}
+	}
+	v, err := strconv.ParseFloat(s.text[i:i+c], 64)
+	if err != nil {
+		panic(fmt.Errorf("xpath: scanNumber parse float got error: %v", err))
+	}
+	return v
+}
+
+func (s *scanner) scanString() string {
+	var (
+		c   = 0
+		end = s.curr
+	)
+	s.nextChar()
+	i := s.pos - 1
+	for s.curr != end {
+		if !s.nextChar() {
+			panic(errors.New("xpath: scanString got unclosed string"))
+		}
+		c++
+	}
+	s.nextChar()
+	return s.text[i : i+c]
+}
+
+func (s *scanner) scanName() string {
+	var (
+		c int
+		i = s.pos - 1
+	)
+	for isName(s.curr) {
+		c++
+		if !s.nextChar() {
+			break
+		}
+	}
+	return s.text[i : i+c]
+}
+
+func isName(r rune) bool {
+	return string(r) != ":" && string(r) != "/" &&
+		(unicode.Is(first, r) || unicode.Is(second, r) || string(r) == "*")
+}
+
+func isDigit(r rune) bool {
+	return unicode.IsDigit(r)
+}
+
+func asItemType(r rune) itemType {
+	switch r {
+	case ',':
+		return itemComma
+	case '@':
+		return itemAt
+	case '(':
+		return itemLParens
+	case ')':
+		return itemRParens
+	case '|':
+		return itemUnion
+	case '*':
+		return itemStar
+	case '[':
+		return itemLBracket
+	case ']':
+		return itemRBracket
+	case '+':
+		return itemPlus
+	case '-':
+		return itemMinus
+	case '=':
+		return itemEq
+	case '$':
+		return itemDollar
+	}
+	panic(fmt.Errorf("unknown item: %v", r))
+}
+
+var first = &unicode.RangeTable{
+	R16: []unicode.Range16{
+		{0x003A, 0x003A, 1},
+		{0x0041, 0x005A, 1},
+		{0x005F, 0x005F, 1},
+		{0x0061, 0x007A, 1},
+		{0x00C0, 0x00D6, 1},
+		{0x00D8, 0x00F6, 1},
+		{0x00F8, 0x00FF, 1},
+		{0x0100, 0x0131, 1},
+		{0x0134, 0x013E, 1},
+		{0x0141, 0x0148, 1},
+		{0x014A, 0x017E, 1},
+		{0x0180, 0x01C3, 1},
+		{0x01CD, 0x01F0, 1},
+		{0x01F4, 0x01F5, 1},
+		{0x01FA, 0x0217, 1},
+		{0x0250, 0x02A8, 1},
+		{0x02BB, 0x02C1, 1},
+		{0x0386, 0x0386, 1},
+		{0x0388, 0x038A, 1},
+		{0x038C, 0x038C, 1},
+		{0x038E, 0x03A1, 1},
+		{0x03A3, 0x03CE, 1},
+		{0x03D0, 0x03D6, 1},
+		{0x03DA, 0x03E0, 2},
+		{0x03E2, 0x03F3, 1},
+		{0x0401, 0x040C, 1},
+		{0x040E, 0x044F, 1},
+		{0x0451, 0x045C, 1},
+		{0x045E, 0x0481, 1},
+		{0x0490, 0x04C4, 1},
+		{0x04C7, 0x04C8, 1},
+		{0x04CB, 0x04CC, 1},
+		{0x04D0, 0x04EB, 1},
+		{0x04EE, 0x04F5, 1},
+		{0x04F8, 0x04F9, 1},
+		{0x0531, 0x0556, 1},
+		{0x0559, 0x0559, 1},
+		{0x0561, 0x0586, 1},
+		{0x05D0, 0x05EA, 1},
+		{0x05F0, 0x05F2, 1},
+		{0x0621, 0x063A, 1},
+		{0x0641, 0x064A, 1},
+		{0x0671, 0x06B7, 1},
+		{0x06BA, 0x06BE, 1},
+		{0x06C0, 0x06CE, 1},
+		{0x06D0, 0x06D3, 1},
+		{0x06D5, 0x06D5, 1},
+		{0x06E5, 0x06E6, 1},
+		{0x0905, 0x0939, 1},
+		{0x093D, 0x093D, 1},
+		{0x0958, 0x0961, 1},
+		{0x0985, 0x098C, 1},
+		{0x098F, 0x0990, 1},
+		{0x0993, 0x09A8, 1},
+		{0x09AA, 0x09B0, 1},
+		{0x09B2, 0x09B2, 1},
+		{0x09B6, 0x09B9, 1},
+		{0x09DC, 0x09DD, 1},
+		{0x09DF, 0x09E1, 1},
+		{0x09F0, 0x09F1, 1},
+		{0x0A05, 0x0A0A, 1},
+		{0x0A0F, 0x0A10, 1},
+		{0x0A13, 0x0A28, 1},
+		{0x0A2A, 0x0A30, 1},
+		{0x0A32, 0x0A33, 1},
+		{0x0A35, 0x0A36, 1},
+		{0x0A38, 0x0A39, 1},
+		{0x0A59, 0x0A5C, 1},
+		{0x0A5E, 0x0A5E, 1},
+		{0x0A72, 0x0A74, 1},
+		{0x0A85, 0x0A8B, 1},
+		{0x0A8D, 0x0A8D, 1},
+		{0x0A8F, 0x0A91, 1},
+		{0x0A93, 0x0AA8, 1},
+		{0x0AAA, 0x0AB0, 1},
+		{0x0AB2, 0x0AB3, 1},
+		{0x0AB5, 0x0AB9, 1},
+		{0x0ABD, 0x0AE0, 0x23},
+		{0x0B05, 0x0B0C, 1},
+		{0x0B0F, 0x0B10, 1},
+		{0x0B13, 0x0B28, 1},
+		{0x0B2A, 0x0B30, 1},
+		{0x0B32, 0x0B33, 1},
+		{0x0B36, 0x0B39, 1},
+		{0x0B3D, 0x0B3D, 1},
+		{0x0B5C, 0x0B5D, 1},
+		{0x0B5F, 0x0B61, 1},
+		{0x0B85, 0x0B8A, 1},
+		{0x0B8E, 0x0B90, 1},
+		{0x0B92, 0x0B95, 1},
+		{0x0B99, 0x0B9A, 1},
+		{0x0B9C, 0x0B9C, 1},
+		{0x0B9E, 0x0B9F, 1},
+		{0x0BA3, 0x0BA4, 1},
+		{0x0BA8, 0x0BAA, 1},
+		{0x0BAE, 0x0BB5, 1},
+		{0x0BB7, 0x0BB9, 1},
+		{0x0C05, 0x0C0C, 1},
+		{0x0C0E, 0x0C10, 1},
+		{0x0C12, 0x0C28, 1},
+		{0x0C2A, 0x0C33, 1},
+		{0x0C35, 0x0C39, 1},
+		{0x0C60, 0x0C61, 1},
+		{0x0C85, 0x0C8C, 1},
+		{0x0C8E, 0x0C90, 1},
+		{0x0C92, 0x0CA8, 1},
+		{0x0CAA, 0x0CB3, 1},
+		{0x0CB5, 0x0CB9, 1},
+		{0x0CDE, 0x0CDE, 1},
+		{0x0CE0, 0x0CE1, 1},
+		{0x0D05, 0x0D0C, 1},
+		{0x0D0E, 0x0D10, 1},
+		{0x0D12, 0x0D28, 1},
+		{0x0D2A, 0x0D39, 1},
+		{0x0D60, 0x0D61, 1},
+		{0x0E01, 0x0E2E, 1},
+		{0x0E30, 0x0E30, 1},
+		{0x0E32, 0x0E33, 1},
+		{0x0E40, 0x0E45, 1},
+		{0x0E81, 0x0E82, 1},
+		{0x0E84, 0x0E84, 1},
+		{0x0E87, 0x0E88, 1},
+		{0x0E8A, 0x0E8D, 3},
+		{0x0E94, 0x0E97, 1},
+		{0x0E99, 0x0E9F, 1},
+		{0x0EA1, 0x0EA3, 1},
+		{0x0EA5, 0x0EA7, 2},
+		{0x0EAA, 0x0EAB, 1},
+		{0x0EAD, 0x0EAE, 1},
+		{0x0EB0, 0x0EB0, 1},
+		{0x0EB2, 0x0EB3, 1},
+		{0x0EBD, 0x0EBD, 1},
+		{0x0EC0, 0x0EC4, 1},
+		{0x0F40, 0x0F47, 1},
+		{0x0F49, 0x0F69, 1},
+		{0x10A0, 0x10C5, 1},
+		{0x10D0, 0x10F6, 1},
+		{0x1100, 0x1100, 1},
+		{0x1102, 0x1103, 1},
+		{0x1105, 0x1107, 1},
+		{0x1109, 0x1109, 1},
+		{0x110B, 0x110C, 1},
+		{0x110E, 0x1112, 1},
+		{0x113C, 0x1140, 2},
+		{0x114C, 0x1150, 2},
+		{0x1154, 0x1155, 1},
+		{0x1159, 0x1159, 1},
+		{0x115F, 0x1161, 1},
+		{0x1163, 0x1169, 2},
+		{0x116D, 0x116E, 1},
+		{0x1172, 0x1173, 1},
+		{0x1175, 0x119E, 0x119E - 0x1175},
+		{0x11A8, 0x11AB, 0x11AB - 0x11A8},
+		{0x11AE, 0x11AF, 1},
+		{0x11B7, 0x11B8, 1},
+		{0x11BA, 0x11BA, 1},
+		{0x11BC, 0x11C2, 1},
+		{0x11EB, 0x11F0, 0x11F0 - 0x11EB},
+		{0x11F9, 0x11F9, 1},
+		{0x1E00, 0x1E9B, 1},
+		{0x1EA0, 0x1EF9, 1},
+		{0x1F00, 0x1F15, 1},
+		{0x1F18, 0x1F1D, 1},
+		{0x1F20, 0x1F45, 1},
+		{0x1F48, 0x1F4D, 1},
+		{0x1F50, 0x1F57, 1},
+		{0x1F59, 0x1F5B, 0x1F5B - 0x1F59},
+		{0x1F5D, 0x1F5D, 1},
+		{0x1F5F, 0x1F7D, 1},
+		{0x1F80, 0x1FB4, 1},
+		{0x1FB6, 0x1FBC, 1},
+		{0x1FBE, 0x1FBE, 1},
+		{0x1FC2, 0x1FC4, 1},
+		{0x1FC6, 0x1FCC, 1},
+		{0x1FD0, 0x1FD3, 1},
+		{0x1FD6, 0x1FDB, 1},
+		{0x1FE0, 0x1FEC, 1},
+		{0x1FF2, 0x1FF4, 1},
+		{0x1FF6, 0x1FFC, 1},
+		{0x2126, 0x2126, 1},
+		{0x212A, 0x212B, 1},
+		{0x212E, 0x212E, 1},
+		{0x2180, 0x2182, 1},
+		{0x3007, 0x3007, 1},
+		{0x3021, 0x3029, 1},
+		{0x3041, 0x3094, 1},
+		{0x30A1, 0x30FA, 1},
+		{0x3105, 0x312C, 1},
+		{0x4E00, 0x9FA5, 1},
+		{0xAC00, 0xD7A3, 1},
+	},
+}
+
+var second = &unicode.RangeTable{
+	R16: []unicode.Range16{
+		{0x002D, 0x002E, 1},
+		{0x0030, 0x0039, 1},
+		{0x00B7, 0x00B7, 1},
+		{0x02D0, 0x02D1, 1},
+		{0x0300, 0x0345, 1},
+		{0x0360, 0x0361, 1},
+		{0x0387, 0x0387, 1},
+		{0x0483, 0x0486, 1},
+		{0x0591, 0x05A1, 1},
+		{0x05A3, 0x05B9, 1},
+		{0x05BB, 0x05BD, 1},
+		{0x05BF, 0x05BF, 1},
+		{0x05C1, 0x05C2, 1},
+		{0x05C4, 0x0640, 0x0640 - 0x05C4},
+		{0x064B, 0x0652, 1},
+		{0x0660, 0x0669, 1},
+		{0x0670, 0x0670, 1},
+		{0x06D6, 0x06DC, 1},
+		{0x06DD, 0x06DF, 1},
+		{0x06E0, 0x06E4, 1},
+		{0x06E7, 0x06E8, 1},
+		{0x06EA, 0x06ED, 1},
+		{0x06F0, 0x06F9, 1},
+		{0x0901, 0x0903, 1},
+		{0x093C, 0x093C, 1},
+		{0x093E, 0x094C, 1},
+		{0x094D, 0x094D, 1},
+		{0x0951, 0x0954, 1},
+		{0x0962, 0x0963, 1},
+		{0x0966, 0x096F, 1},
+		{0x0981, 0x0983, 1},
+		{0x09BC, 0x09BC, 1},
+		{0x09BE, 0x09BF, 1},
+		{0x09C0, 0x09C4, 1},
+		{0x09C7, 0x09C8, 1},
+		{0x09CB, 0x09CD, 1},
+		{0x09D7, 0x09D7, 1},
+		{0x09E2, 0x09E3, 1},
+		{0x09E6, 0x09EF, 1},
+		{0x0A02, 0x0A3C, 0x3A},
+		{0x0A3E, 0x0A3F, 1},
+		{0x0A40, 0x0A42, 1},
+		{0x0A47, 0x0A48, 1},
+		{0x0A4B, 0x0A4D, 1},
+		{0x0A66, 0x0A6F, 1},
+		{0x0A70, 0x0A71, 1},
+		{0x0A81, 0x0A83, 1},
+		{0x0ABC, 0x0ABC, 1},
+		{0x0ABE, 0x0AC5, 1},
+		{0x0AC7, 0x0AC9, 1},
+		{0x0ACB, 0x0ACD, 1},
+		{0x0AE6, 0x0AEF, 1},
+		{0x0B01, 0x0B03, 1},
+		{0x0B3C, 0x0B3C, 1},
+		{0x0B3E, 0x0B43, 1},
+		{0x0B47, 0x0B48, 1},
+		{0x0B4B, 0x0B4D, 1},
+		{0x0B56, 0x0B57, 1},
+		{0x0B66, 0x0B6F, 1},
+		{0x0B82, 0x0B83, 1},
+		{0x0BBE, 0x0BC2, 1},
+		{0x0BC6, 0x0BC8, 1},
+		{0x0BCA, 0x0BCD, 1},
+		{0x0BD7, 0x0BD7, 1},
+		{0x0BE7, 0x0BEF, 1},
+		{0x0C01, 0x0C03, 1},
+		{0x0C3E, 0x0C44, 1},
+		{0x0C46, 0x0C48, 1},
+		{0x0C4A, 0x0C4D, 1},
+		{0x0C55, 0x0C56, 1},
+		{0x0C66, 0x0C6F, 1},
+		{0x0C82, 0x0C83, 1},
+		{0x0CBE, 0x0CC4, 1},
+		{0x0CC6, 0x0CC8, 1},
+		{0x0CCA, 0x0CCD, 1},
+		{0x0CD5, 0x0CD6, 1},
+		{0x0CE6, 0x0CEF, 1},
+		{0x0D02, 0x0D03, 1},
+		{0x0D3E, 0x0D43, 1},
+		{0x0D46, 0x0D48, 1},
+		{0x0D4A, 0x0D4D, 1},
+		{0x0D57, 0x0D57, 1},
+		{0x0D66, 0x0D6F, 1},
+		{0x0E31, 0x0E31, 1},
+		{0x0E34, 0x0E3A, 1},
+		{0x0E46, 0x0E46, 1},
+		{0x0E47, 0x0E4E, 1},
+		{0x0E50, 0x0E59, 1},
+		{0x0EB1, 0x0EB1, 1},
+		{0x0EB4, 0x0EB9, 1},
+		{0x0EBB, 0x0EBC, 1},
+		{0x0EC6, 0x0EC6, 1},
+		{0x0EC8, 0x0ECD, 1},
+		{0x0ED0, 0x0ED9, 1},
+		{0x0F18, 0x0F19, 1},
+		{0x0F20, 0x0F29, 1},
+		{0x0F35, 0x0F39, 2},
+		{0x0F3E, 0x0F3F, 1},
+		{0x0F71, 0x0F84, 1},
+		{0x0F86, 0x0F8B, 1},
+		{0x0F90, 0x0F95, 1},
+		{0x0F97, 0x0F97, 1},
+		{0x0F99, 0x0FAD, 1},
+		{0x0FB1, 0x0FB7, 1},
+		{0x0FB9, 0x0FB9, 1},
+		{0x20D0, 0x20DC, 1},
+		{0x20E1, 0x3005, 0x3005 - 0x20E1},
+		{0x302A, 0x302F, 1},
+		{0x3031, 0x3035, 1},
+		{0x3099, 0x309A, 1},
+		{0x309D, 0x309E, 1},
+		{0x30FC, 0x30FE, 1},
+	},
+}

--- a/vendor/github.com/antchfx/xpath/query.go
+++ b/vendor/github.com/antchfx/xpath/query.go
@@ -1,0 +1,791 @@
+package xpath
+
+import (
+	"reflect"
+)
+
+type iterator interface {
+	Current() NodeNavigator
+}
+
+// An XPath query interface.
+type query interface {
+	// Select traversing iterator returns a query matched node NodeNavigator.
+	Select(iterator) NodeNavigator
+
+	// Evaluate evaluates query and returns values of the current query.
+	Evaluate(iterator) interface{}
+
+	Clone() query
+}
+
+// contextQuery is returns current node on the iterator object query.
+type contextQuery struct {
+	count int
+	Root  bool // Moving to root-level node in the current context iterator.
+}
+
+func (c *contextQuery) Select(t iterator) (n NodeNavigator) {
+	if c.count == 0 {
+		c.count++
+		n = t.Current().Copy()
+		if c.Root {
+			n.MoveToRoot()
+		}
+	}
+	return n
+}
+
+func (c *contextQuery) Evaluate(iterator) interface{} {
+	c.count = 0
+	return c
+}
+
+func (c *contextQuery) Clone() query {
+	return &contextQuery{count: 0, Root: c.Root}
+}
+
+// ancestorQuery is an XPath ancestor node query.(ancestor::*|ancestor-self::*)
+type ancestorQuery struct {
+	iterator func() NodeNavigator
+
+	Self      bool
+	Input     query
+	Predicate func(NodeNavigator) bool
+}
+
+func (a *ancestorQuery) Select(t iterator) NodeNavigator {
+	for {
+		if a.iterator == nil {
+			node := a.Input.Select(t)
+			if node == nil {
+				return nil
+			}
+			first := true
+			a.iterator = func() NodeNavigator {
+				if first && a.Self {
+					first = false
+					if a.Predicate(node) {
+						return node
+					}
+				}
+				for node.MoveToParent() {
+					if !a.Predicate(node) {
+						break
+					}
+					return node
+				}
+				return nil
+			}
+		}
+
+		if node := a.iterator(); node != nil {
+			return node
+		}
+		a.iterator = nil
+	}
+}
+
+func (a *ancestorQuery) Evaluate(t iterator) interface{} {
+	a.Input.Evaluate(t)
+	a.iterator = nil
+	return a
+}
+
+func (a *ancestorQuery) Test(n NodeNavigator) bool {
+	return a.Predicate(n)
+}
+
+func (a *ancestorQuery) Clone() query {
+	return &ancestorQuery{Self: a.Self, Input: a.Input.Clone(), Predicate: a.Predicate}
+}
+
+// attributeQuery is an XPath attribute node query.(@*)
+type attributeQuery struct {
+	iterator func() NodeNavigator
+
+	Input     query
+	Predicate func(NodeNavigator) bool
+}
+
+func (a *attributeQuery) Select(t iterator) NodeNavigator {
+	for {
+		if a.iterator == nil {
+			node := a.Input.Select(t)
+			if node == nil {
+				return nil
+			}
+			node = node.Copy()
+			a.iterator = func() NodeNavigator {
+				for {
+					onAttr := node.MoveToNextAttribute()
+					if !onAttr {
+						return nil
+					}
+					if a.Predicate(node) {
+						return node
+					}
+				}
+			}
+		}
+
+		if node := a.iterator(); node != nil {
+			return node
+		}
+		a.iterator = nil
+	}
+}
+
+func (a *attributeQuery) Evaluate(t iterator) interface{} {
+	a.Input.Evaluate(t)
+	a.iterator = nil
+	return a
+}
+
+func (a *attributeQuery) Test(n NodeNavigator) bool {
+	return a.Predicate(n)
+}
+
+func (a *attributeQuery) Clone() query {
+	return &attributeQuery{Input: a.Input.Clone(), Predicate: a.Predicate}
+}
+
+// childQuery is an XPath child node query.(child::*)
+type childQuery struct {
+	posit    int
+	iterator func() NodeNavigator
+
+	Input     query
+	Predicate func(NodeNavigator) bool
+}
+
+func (c *childQuery) Select(t iterator) NodeNavigator {
+	for {
+		if c.iterator == nil {
+			c.posit = 0
+			node := c.Input.Select(t)
+			if node == nil {
+				return nil
+			}
+			node = node.Copy()
+			first := true
+			c.iterator = func() NodeNavigator {
+				for {
+					if (first && !node.MoveToChild()) || (!first && !node.MoveToNext()) {
+						return nil
+					}
+					first = false
+					if c.Predicate(node) {
+						return node
+					}
+				}
+			}
+		}
+
+		if node := c.iterator(); node != nil {
+			c.posit++
+			return node
+		}
+		c.iterator = nil
+	}
+}
+
+func (c *childQuery) Evaluate(t iterator) interface{} {
+	c.Input.Evaluate(t)
+	c.iterator = nil
+	return c
+}
+
+func (c *childQuery) Test(n NodeNavigator) bool {
+	return c.Predicate(n)
+}
+
+func (c *childQuery) Clone() query {
+	return &childQuery{Input: c.Input.Clone(), Predicate: c.Predicate}
+}
+
+// position returns a position of current NodeNavigator.
+func (c *childQuery) position() int {
+	return c.posit
+}
+
+// descendantQuery is an XPath descendant node query.(descendant::* | descendant-or-self::*)
+type descendantQuery struct {
+	iterator func() NodeNavigator
+	posit    int
+
+	Self      bool
+	Input     query
+	Predicate func(NodeNavigator) bool
+}
+
+func (d *descendantQuery) Select(t iterator) NodeNavigator {
+	for {
+		if d.iterator == nil {
+			d.posit = 0
+			node := d.Input.Select(t)
+			if node == nil {
+				return nil
+			}
+			node = node.Copy()
+			level := 0
+			first := true
+			d.iterator = func() NodeNavigator {
+				if first && d.Self {
+					first = false
+					if d.Predicate(node) {
+						return node
+					}
+				}
+
+				for {
+					if node.MoveToChild() {
+						level++
+					} else {
+						for {
+							if level == 0 {
+								return nil
+							}
+							if node.MoveToNext() {
+								break
+							}
+							node.MoveToParent()
+							level--
+						}
+					}
+					if d.Predicate(node) {
+						return node
+					}
+				}
+			}
+		}
+
+		if node := d.iterator(); node != nil {
+			d.posit++
+			return node
+		}
+		d.iterator = nil
+	}
+}
+
+func (d *descendantQuery) Evaluate(t iterator) interface{} {
+	d.Input.Evaluate(t)
+	d.iterator = nil
+	return d
+}
+
+func (d *descendantQuery) Test(n NodeNavigator) bool {
+	return d.Predicate(n)
+}
+
+// position returns a position of current NodeNavigator.
+func (d *descendantQuery) position() int {
+	return d.posit
+}
+
+func (d *descendantQuery) Clone() query {
+	return &descendantQuery{Self: d.Self, Input: d.Input.Clone(), Predicate: d.Predicate}
+}
+
+// followingQuery is an XPath following node query.(following::*|following-sibling::*)
+type followingQuery struct {
+	iterator func() NodeNavigator
+
+	Input     query
+	Sibling   bool // The matching sibling node of current node.
+	Predicate func(NodeNavigator) bool
+}
+
+func (f *followingQuery) Select(t iterator) NodeNavigator {
+	for {
+		if f.iterator == nil {
+			node := f.Input.Select(t)
+			if node == nil {
+				return nil
+			}
+			node = node.Copy()
+			if f.Sibling {
+				f.iterator = func() NodeNavigator {
+					for {
+						if !node.MoveToNext() {
+							return nil
+						}
+						if f.Predicate(node) {
+							return node
+						}
+					}
+				}
+			} else {
+				var q query // descendant query
+				f.iterator = func() NodeNavigator {
+					for {
+						if q == nil {
+							for !node.MoveToNext() {
+								if !node.MoveToParent() {
+									return nil
+								}
+							}
+							q = &descendantQuery{
+								Self:      true,
+								Input:     &contextQuery{},
+								Predicate: f.Predicate,
+							}
+							t.Current().MoveTo(node)
+						}
+						if node := q.Select(t); node != nil {
+							return node
+						}
+						q = nil
+					}
+				}
+			}
+		}
+
+		if node := f.iterator(); node != nil {
+			return node
+		}
+		f.iterator = nil
+	}
+}
+
+func (f *followingQuery) Evaluate(t iterator) interface{} {
+	f.Input.Evaluate(t)
+	return f
+}
+
+func (f *followingQuery) Test(n NodeNavigator) bool {
+	return f.Predicate(n)
+}
+
+func (f *followingQuery) Clone() query {
+	return &followingQuery{Input: f.Input.Clone(), Sibling: f.Sibling, Predicate: f.Predicate}
+}
+
+// precedingQuery is an XPath preceding node query.(preceding::*)
+type precedingQuery struct {
+	iterator  func() NodeNavigator
+	Input     query
+	Sibling   bool // The matching sibling node of current node.
+	Predicate func(NodeNavigator) bool
+}
+
+func (p *precedingQuery) Select(t iterator) NodeNavigator {
+	for {
+		if p.iterator == nil {
+			node := p.Input.Select(t)
+			if node == nil {
+				return nil
+			}
+			node = node.Copy()
+			if p.Sibling {
+				p.iterator = func() NodeNavigator {
+					for {
+						for !node.MoveToPrevious() {
+							return nil
+						}
+						if p.Predicate(node) {
+							return node
+						}
+					}
+				}
+			} else {
+				var q query
+				p.iterator = func() NodeNavigator {
+					for {
+						if q == nil {
+							for !node.MoveToPrevious() {
+								if !node.MoveToParent() {
+									return nil
+								}
+							}
+							q = &descendantQuery{
+								Self:      true,
+								Input:     &contextQuery{},
+								Predicate: p.Predicate,
+							}
+							t.Current().MoveTo(node)
+						}
+						if node := q.Select(t); node != nil {
+							return node
+						}
+						q = nil
+					}
+				}
+			}
+		}
+		if node := p.iterator(); node != nil {
+			return node
+		}
+		p.iterator = nil
+	}
+}
+
+func (p *precedingQuery) Evaluate(t iterator) interface{} {
+	p.Input.Evaluate(t)
+	return p
+}
+
+func (p *precedingQuery) Test(n NodeNavigator) bool {
+	return p.Predicate(n)
+}
+
+func (p *precedingQuery) Clone() query {
+	return &precedingQuery{Input: p.Input.Clone(), Sibling: p.Sibling, Predicate: p.Predicate}
+}
+
+// parentQuery is an XPath parent node query.(parent::*)
+type parentQuery struct {
+	Input     query
+	Predicate func(NodeNavigator) bool
+}
+
+func (p *parentQuery) Select(t iterator) NodeNavigator {
+	for {
+		node := p.Input.Select(t)
+		if node == nil {
+			return nil
+		}
+		node = node.Copy()
+		if node.MoveToParent() && p.Predicate(node) {
+			return node
+		}
+	}
+}
+
+func (p *parentQuery) Evaluate(t iterator) interface{} {
+	p.Input.Evaluate(t)
+	return p
+}
+
+func (p *parentQuery) Clone() query {
+	return &parentQuery{Input: p.Input.Clone(), Predicate: p.Predicate}
+}
+
+func (p *parentQuery) Test(n NodeNavigator) bool {
+	return p.Predicate(n)
+}
+
+// selfQuery is an Self node query.(self::*)
+type selfQuery struct {
+	Input     query
+	Predicate func(NodeNavigator) bool
+}
+
+func (s *selfQuery) Select(t iterator) NodeNavigator {
+	for {
+		node := s.Input.Select(t)
+		if node == nil {
+			return nil
+		}
+
+		if s.Predicate(node) {
+			return node
+		}
+	}
+}
+
+func (s *selfQuery) Evaluate(t iterator) interface{} {
+	s.Input.Evaluate(t)
+	return s
+}
+
+func (s *selfQuery) Test(n NodeNavigator) bool {
+	return s.Predicate(n)
+}
+
+func (s *selfQuery) Clone() query {
+	return &selfQuery{Input: s.Input.Clone(), Predicate: s.Predicate}
+}
+
+// filterQuery is an XPath query for predicate filter.
+type filterQuery struct {
+	Input     query
+	Predicate query
+}
+
+func (f *filterQuery) do(t iterator) bool {
+	val := reflect.ValueOf(f.Predicate.Evaluate(t))
+	switch val.Kind() {
+	case reflect.Bool:
+		return val.Bool()
+	case reflect.String:
+		return len(val.String()) > 0
+	case reflect.Float64:
+		pt := float64(getNodePosition(f.Input))
+		return int(val.Float()) == int(pt)
+	default:
+		if q, ok := f.Predicate.(query); ok {
+			return q.Select(t) != nil
+		}
+	}
+	return false
+}
+
+func (f *filterQuery) Select(t iterator) NodeNavigator {
+	for {
+		node := f.Input.Select(t)
+		if node == nil {
+			return node
+		}
+		node = node.Copy()
+		//fmt.Println(node.LocalName())
+
+		t.Current().MoveTo(node)
+		if f.do(t) {
+			return node
+		}
+	}
+}
+
+func (f *filterQuery) Evaluate(t iterator) interface{} {
+	f.Input.Evaluate(t)
+	return f
+}
+
+func (f *filterQuery) Clone() query {
+	return &filterQuery{Input: f.Input.Clone(), Predicate: f.Predicate.Clone()}
+}
+
+// functionQuery is an XPath function that call a function to returns
+// value of current NodeNavigator node.
+type functionQuery struct {
+	Input query                             // Node Set
+	Func  func(query, iterator) interface{} // The xpath function.
+}
+
+func (f *functionQuery) Select(t iterator) NodeNavigator {
+	return nil
+}
+
+// Evaluate call a specified function that will returns the
+// following value type: number,string,boolean.
+func (f *functionQuery) Evaluate(t iterator) interface{} {
+	return f.Func(f.Input, t)
+}
+
+func (f *functionQuery) Clone() query {
+	return &functionQuery{Input: f.Input.Clone(), Func: f.Func}
+}
+
+// constantQuery is an XPath constant operand.
+type constantQuery struct {
+	Val interface{}
+}
+
+func (c *constantQuery) Select(t iterator) NodeNavigator {
+	return nil
+}
+
+func (c *constantQuery) Evaluate(t iterator) interface{} {
+	return c.Val
+}
+
+func (c *constantQuery) Clone() query {
+	return c
+}
+
+// logicalQuery is an XPath logical expression.
+type logicalQuery struct {
+	Left, Right query
+
+	Do func(iterator, interface{}, interface{}) interface{}
+}
+
+func (l *logicalQuery) Select(t iterator) NodeNavigator {
+	// When a XPath expr is logical expression.
+	node := t.Current().Copy()
+	val := l.Evaluate(t)
+	switch val.(type) {
+	case bool:
+		if val.(bool) == true {
+			return node
+		}
+	}
+	return nil
+}
+
+func (l *logicalQuery) Evaluate(t iterator) interface{} {
+	m := l.Left.Evaluate(t)
+	n := l.Right.Evaluate(t)
+	return l.Do(t, m, n)
+}
+
+func (l *logicalQuery) Clone() query {
+	return &logicalQuery{Left: l.Left.Clone(), Right: l.Right.Clone(), Do: l.Do}
+}
+
+// numericQuery is an XPath numeric operator expression.
+type numericQuery struct {
+	Left, Right query
+
+	Do func(interface{}, interface{}) interface{}
+}
+
+func (n *numericQuery) Select(t iterator) NodeNavigator {
+	return nil
+}
+
+func (n *numericQuery) Evaluate(t iterator) interface{} {
+	m := n.Left.Evaluate(t)
+	k := n.Right.Evaluate(t)
+	return n.Do(m, k)
+}
+
+func (n *numericQuery) Clone() query {
+	return &numericQuery{Left: n.Left.Clone(), Right: n.Right.Clone(), Do: n.Do}
+}
+
+type booleanQuery struct {
+	IsOr        bool
+	Left, Right query
+	iterator    func() NodeNavigator
+}
+
+func (b *booleanQuery) Select(t iterator) NodeNavigator {
+	if b.iterator == nil {
+		var list []NodeNavigator
+		i := 0
+		root := t.Current().Copy()
+		if b.IsOr {
+			for {
+				node := b.Left.Select(t)
+				if node == nil {
+					break
+				}
+				node = node.Copy()
+				list = append(list, node)
+			}
+			t.Current().MoveTo(root)
+			for {
+				node := b.Right.Select(t)
+				if node == nil {
+					break
+				}
+				node = node.Copy()
+				list = append(list, node)
+			}
+		} else {
+			var m []NodeNavigator
+			var n []NodeNavigator
+			for {
+				node := b.Left.Select(t)
+				if node == nil {
+					break
+				}
+				node = node.Copy()
+				list = append(m, node)
+			}
+			t.Current().MoveTo(root)
+			for {
+				node := b.Right.Select(t)
+				if node == nil {
+					break
+				}
+				node = node.Copy()
+				list = append(n, node)
+			}
+			for _, k := range m {
+				for _, j := range n {
+					if k == j {
+						list = append(list, k)
+					}
+				}
+			}
+		}
+
+		b.iterator = func() NodeNavigator {
+			if i >= len(list) {
+				return nil
+			}
+			node := list[i]
+			i++
+			return node
+		}
+	}
+	return b.iterator()
+}
+
+func (b *booleanQuery) Evaluate(t iterator) interface{} {
+	m := b.Left.Evaluate(t)
+	left := asBool(t, m)
+	if b.IsOr && left {
+		return true
+	} else if !b.IsOr && !left {
+		return false
+	}
+	m = b.Right.Evaluate(t)
+	return asBool(t, m)
+}
+
+func (b *booleanQuery) Clone() query {
+	return &booleanQuery{IsOr: b.IsOr, Left: b.Left.Clone(), Right: b.Right.Clone()}
+}
+
+type unionQuery struct {
+	Left, Right query
+	iterator    func() NodeNavigator
+}
+
+func (u *unionQuery) Select(t iterator) NodeNavigator {
+	if u.iterator == nil {
+		var list []NodeNavigator
+		var i int
+		root := t.Current().Copy()
+		for {
+			node := u.Left.Select(t)
+			if node == nil {
+				break
+			}
+			node = node.Copy()
+			list = append(list, node)
+		}
+		t.Current().MoveTo(root)
+		for {
+			node := u.Right.Select(t)
+			if node == nil {
+				break
+			}
+			node = node.Copy()
+			var exists bool
+			for _, x := range list {
+				if reflect.DeepEqual(x, node) {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				list = append(list, node)
+			}
+		}
+		u.iterator = func() NodeNavigator {
+			if i >= len(list) {
+				return nil
+			}
+			node := list[i]
+			i++
+			return node
+		}
+	}
+	return u.iterator()
+}
+
+func (u *unionQuery) Evaluate(t iterator) interface{} {
+	u.iterator = nil
+	u.Left.Evaluate(t)
+	u.Right.Evaluate(t)
+	return u
+}
+
+func (u *unionQuery) Clone() query {
+	return &unionQuery{Left: u.Left.Clone(), Right: u.Right.Clone()}
+}
+
+func getNodePosition(q query) int {
+	type Position interface {
+		position() int
+	}
+	if count, ok := q.(Position); ok {
+		return count.position()
+	}
+	return 1
+}

--- a/vendor/github.com/antchfx/xpath/xpath.go
+++ b/vendor/github.com/antchfx/xpath/xpath.go
@@ -1,0 +1,157 @@
+package xpath
+
+import (
+	"errors"
+)
+
+// NodeType represents a type of XPath node.
+type NodeType int
+
+const (
+	// RootNode is a root node of the XML document or node tree.
+	RootNode NodeType = iota
+
+	// ElementNode is an element, such as <element>.
+	ElementNode
+
+	// AttributeNode is an attribute, such as id='123'.
+	AttributeNode
+
+	// TextNode is the text content of a node.
+	TextNode
+
+	// CommentNode is a comment node, such as <!-- my comment -->
+	CommentNode
+
+	// allNode is any types of node, used by xpath package only to predicate match.
+	allNode
+)
+
+// NodeNavigator provides cursor model for navigating XML data.
+type NodeNavigator interface {
+	// NodeType returns the XPathNodeType of the current node.
+	NodeType() NodeType
+
+	// LocalName gets the Name of the current node.
+	LocalName() string
+
+	// Prefix returns namespace prefix associated with the current node.
+	Prefix() string
+
+	// Value gets the value of current node.
+	Value() string
+
+	// Copy does a deep copy of the NodeNavigator and all its components.
+	Copy() NodeNavigator
+
+	// MoveToRoot moves the NodeNavigator to the root node of the current node.
+	MoveToRoot()
+
+	// MoveToParent moves the NodeNavigator to the parent node of the current node.
+	MoveToParent() bool
+
+	// MoveToNextAttribute moves the NodeNavigator to the next attribute on current node.
+	MoveToNextAttribute() bool
+
+	// MoveToChild moves the NodeNavigator to the first child node of the current node.
+	MoveToChild() bool
+
+	// MoveToFirst moves the NodeNavigator to the first sibling node of the current node.
+	MoveToFirst() bool
+
+	// MoveToNext moves the NodeNavigator to the next sibling node of the current node.
+	MoveToNext() bool
+
+	// MoveToPrevious moves the NodeNavigator to the previous sibling node of the current node.
+	MoveToPrevious() bool
+
+	// MoveTo moves the NodeNavigator to the same position as the specified NodeNavigator.
+	MoveTo(NodeNavigator) bool
+}
+
+// NodeIterator holds all matched Node object.
+type NodeIterator struct {
+	node  NodeNavigator
+	query query
+}
+
+// Current returns current node which matched.
+func (t *NodeIterator) Current() NodeNavigator {
+	return t.node
+}
+
+// MoveNext moves Navigator to the next match node.
+func (t *NodeIterator) MoveNext() bool {
+	n := t.query.Select(t)
+	if n != nil {
+		if !t.node.MoveTo(n) {
+			t.node = n.Copy()
+		}
+		return true
+	}
+	return false
+}
+
+// Select selects a node set using the specified XPath expression.
+// This method is deprecated, recommend using Expr.Select() method instead.
+func Select(root NodeNavigator, expr string) *NodeIterator {
+	exp, err := Compile(expr)
+	if err != nil {
+		panic(err)
+	}
+	return exp.Select(root)
+}
+
+// Expr is an XPath expression for query.
+type Expr struct {
+	s string
+	q query
+}
+
+type iteratorFunc func() NodeNavigator
+
+func (f iteratorFunc) Current() NodeNavigator {
+	return f()
+}
+
+// Evaluate returns the result of the expression.
+// The result type of the expression is one of the follow: bool,float64,string,NodeIterator).
+func (expr *Expr) Evaluate(root NodeNavigator) interface{} {
+	val := expr.q.Evaluate(iteratorFunc(func() NodeNavigator { return root }))
+	switch val.(type) {
+	case query:
+		return &NodeIterator{query: expr.q.Clone(), node: root}
+	}
+	return val
+}
+
+// Select selects a node set using the specified XPath expression.
+func (expr *Expr) Select(root NodeNavigator) *NodeIterator {
+	return &NodeIterator{query: expr.q.Clone(), node: root}
+}
+
+// String returns XPath expression string.
+func (expr *Expr) String() string {
+	return expr.s
+}
+
+// Compile compiles an XPath expression string.
+func Compile(expr string) (*Expr, error) {
+	if expr == "" {
+		return nil, errors.New("expr expression is nil")
+	}
+	qy, err := build(expr)
+	if err != nil {
+		return nil, err
+	}
+	return &Expr{s: expr, q: qy}, nil
+}
+
+// MustCompile compiles an XPath expression string and ignored error.
+func MustCompile(expr string) *Expr {
+	exp, err := Compile(expr)
+	if err != nil {
+		return nil
+	}
+	return exp
+}

--- a/vendor/gopkg.in/bblfsh/sdk.v2/driver/driver.go
+++ b/vendor/gopkg.in/bblfsh/sdk.v2/driver/driver.go
@@ -4,6 +4,7 @@ package driver
 import (
 	"bytes"
 	"context"
+	"fmt"
 
 	"gopkg.in/bblfsh/sdk.v2/driver/manifest"
 	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
@@ -19,6 +20,19 @@ const (
 )
 
 const ModeDefault = ModeSemantic
+
+// Parse mode parses a UAST mode string to an enum value.
+func ParseMode(mode string) (Mode, error) {
+	switch mode {
+	case "native":
+		return ModeNative, nil
+	case "annotated":
+		return ModeAnnotated, nil
+	case "semantic":
+		return ModeSemantic, nil
+	}
+	return 0, fmt.Errorf("unsupported mode: %q", mode)
+}
 
 // Module is an interface for a generic module instance.
 type Module interface {

--- a/vendor/gopkg.in/bblfsh/sdk.v2/uast/query/iter.go
+++ b/vendor/gopkg.in/bblfsh/sdk.v2/uast/query/iter.go
@@ -1,0 +1,29 @@
+package query
+
+import (
+	"gopkg.in/bblfsh/sdk.v2/uast"
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+)
+
+type Empty = nodes.Empty
+
+type IterOrder = nodes.IterOrder
+
+const (
+	IterAny       = nodes.IterAny
+	PreOrder      = nodes.PreOrder
+	PostOrder     = nodes.PostOrder
+	LevelOrder    = nodes.LevelOrder
+	PositionOrder = LevelOrder + iota + 1
+)
+
+func NewIterator(root nodes.External, order IterOrder) Iterator {
+	if root == nil {
+		return Empty{}
+	}
+	switch order {
+	case PositionOrder:
+		return uast.NewPositionalIterator(root)
+	}
+	return nodes.NewIterator(root, order)
+}

--- a/vendor/gopkg.in/bblfsh/sdk.v2/uast/query/query.go
+++ b/vendor/gopkg.in/bblfsh/sdk.v2/uast/query/query.go
@@ -1,0 +1,37 @@
+package query
+
+import (
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+)
+
+type Interface interface {
+	// Prepare parses the query and prepares it for repeated execution.
+	Prepare(query string) (Query, error)
+	// Execute prepares and runs a query for a given subtree.
+	Execute(root nodes.External, query string) (Iterator, error)
+}
+
+type Query interface {
+	// Execute runs a query for a given subtree.
+	Execute(root nodes.External) (Iterator, error)
+}
+
+type Iterator = nodes.Iterator
+
+// AllNodes iterates over all nodes and returns them as a slice.
+func AllNodes(it Iterator) []nodes.External {
+	var out []nodes.External
+	for it.Next() {
+		out = append(out, it.Node())
+	}
+	return out
+}
+
+// Count counts the nodes in the iterator. Iterator will be exhausted as a result.
+func Count(it Iterator) int {
+	var n int
+	for it.Next() {
+		n++
+	}
+	return n
+}

--- a/vendor/gopkg.in/bblfsh/sdk.v2/uast/query/xpath/query.go
+++ b/vendor/gopkg.in/bblfsh/sdk.v2/uast/query/xpath/query.go
@@ -1,0 +1,376 @@
+package xpath
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/antchfx/xpath"
+
+	"gopkg.in/bblfsh/sdk.v2/uast"
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+	"gopkg.in/bblfsh/sdk.v2/uast/role"
+)
+
+var _ xpath.NodeNavigator = &nodeNavigator{}
+
+// newNavigator creates a new xpath.nodeNavigator for the specified html.node.
+func newNavigator(root nodes.External) *nodeNavigator {
+	n := &node{n: root, typ: rootNode}
+	return &nodeNavigator{root: n, cur: n, attri: -1}
+}
+
+// A nodeType is the type of a node.
+type nodeType uint
+
+const (
+	// rootNode is a document object that, as the root of the document tree,
+	// provides access to the entire XML document.
+	rootNode nodeType = iota
+	// objectNode is an element.
+	objectNode
+	fieldNode
+	// valueNode is the text content of a node.
+	valueNode
+)
+
+type attr struct {
+	key string
+	val string
+}
+
+type node struct {
+	typ nodeType
+
+	n    nodes.External
+	kind nodes.Kind
+	obj  nodes.ExternalObject
+
+	tag    [2]string
+	attrs  []attr
+	sub    []*node
+	par    *node
+	parInd int // index in parent's sub array
+}
+
+// nodeNavigator is for navigating JSON document.
+type nodeNavigator struct {
+	root, cur *node
+	attri     int
+}
+
+func (a *nodeNavigator) Current() nodes.External {
+	return a.cur.n
+}
+
+func (a *nodeNavigator) NodeType() xpath.NodeType {
+	if a.attri >= 0 {
+		return xpath.AttributeNode
+	}
+	switch a.cur.typ {
+	case valueNode:
+		return xpath.TextNode
+	case rootNode:
+		return xpath.RootNode
+	case objectNode, fieldNode:
+		return xpath.ElementNode
+	default:
+		panic(fmt.Errorf("unknown node type %v", a.cur.typ))
+	}
+}
+
+func (a *nodeNavigator) LocalName() string {
+	if a.attri >= 0 {
+		return a.cur.attrs[a.attri].key
+	}
+	return a.cur.tag[1]
+}
+
+func (a *nodeNavigator) Prefix() string {
+	if a.attri >= 0 {
+		return ""
+	}
+	return a.cur.tag[0]
+}
+
+func (a *nodeNavigator) Value() string {
+	if a.attri >= 0 {
+		return a.cur.attrs[a.attri].val
+	}
+	switch a.cur.typ {
+	case valueNode:
+		return nodes.ToString(a.cur.n.Value())
+	}
+	return ""
+}
+
+func (a *nodeNavigator) Copy() xpath.NodeNavigator {
+	n := *a
+	return &n
+}
+
+func (a *nodeNavigator) MoveToRoot() {
+	a.cur = a.root
+	a.attri = -1
+}
+
+func (a *nodeNavigator) MoveToParent() bool {
+	n := a.cur.par
+	if n == nil {
+		return false
+	}
+	a.cur = n
+	return true
+}
+
+func (x *nodeNavigator) MoveToNextAttribute() bool {
+	if x.cur.attrs == nil && x.cur.obj != nil {
+		x.cur.loadAttributes()
+	}
+	if x.attri+1 < len(x.cur.attrs) {
+		x.attri++
+		return true
+	}
+	return false
+}
+
+func (nd *node) loadAttributes() {
+	nd.attrs = []attr{} // indicate that attributes are loaded even if node has none
+	add := func(k, v string) {
+		nd.attrs = append(nd.attrs, attr{key: k, val: v})
+	}
+	for _, k := range nd.obj.Keys() {
+		v, _ := nd.obj.ValueAt(k)
+		switch sub := v.(type) {
+		case nil:
+			add(k, "")
+			continue
+		case nodes.ExternalArray:
+			// project all array elements that are value to attributes
+
+			isRoles := false
+			if k == uast.KeyRoles {
+				// special case for roles
+				k = "role"
+				isRoles = true
+			}
+
+			sz := sub.Size()
+			for i := 0; i < sz; i++ {
+				vn := sub.ValueAt(i)
+				if vn == nil {
+					add(k, "")
+					continue
+				}
+				kind := vn.Kind()
+				if kind.In(nodes.KindsValues) {
+					v := vn.Value()
+					var av string
+					if isRoles && kind == nodes.KindInt {
+						// role id - convert to string
+						id, _ := v.(nodes.Int)
+						av = role.Role(id).String()
+					} else {
+						av = nodes.ToString(v)
+					}
+					add(k, av)
+				}
+			}
+		case nodes.ExternalObject:
+			if k != uast.KeyPos {
+				continue
+			}
+			// check for position nodes, expand to attributes
+			var pos uast.Positions
+			err := uast.NodeAs(sub, &pos)
+			if err != nil {
+				continue
+			}
+			for _, k := range pos.Keys() {
+				p := pos[k]
+				add(k+"-offset", strconv.FormatUint(uint64(p.Offset), 10))
+				add(k+"-line", strconv.FormatUint(uint64(p.Line), 10))
+				add(k+"-col", strconv.FormatUint(uint64(p.Col), 10))
+			}
+		default:
+			if kind := v.Kind(); kind.In(nodes.KindsValues) {
+				val := v.Value()
+				if k == uast.KeyToken {
+					k = "token"
+				}
+				add(k, nodes.ToString(val))
+				continue
+			}
+		}
+	}
+}
+
+func (nd *node) loadChildren() {
+	// project fields
+	obj := nd.obj
+	keys := obj.Keys()
+	nd.sub = make([]*node, 0, len(keys))
+	for _, k := range keys {
+		v, ok := obj.ValueAt(k)
+		if !ok {
+			continue
+		}
+		var vn *node
+		switch k {
+		case uast.KeyToken:
+			vn = toNode(v, "")
+		default:
+			vn = toNode(v, k)
+		}
+		vn.par = nd
+		vn.parInd = len(nd.sub)
+		nd.sub = append(nd.sub, vn)
+	}
+}
+
+func toNode(n nodes.External, field string) *node {
+	if n == nil || n.Kind() == nodes.KindNil {
+		n = nodes.String("") // TODO
+	}
+	nd := &node{n: n, kind: n.Kind()}
+
+	wrap := func(nd *node) *node {
+		if field == "" {
+			return nd
+		}
+		// wrap node into field-node
+		f := &node{
+			n: nd.n, kind: nd.kind,
+			typ: fieldNode, tag: [2]string{"", field},
+			sub: []*node{nd},
+		}
+		nd.par = f
+		nd.parInd = 0
+		return f
+	}
+
+	switch nd.kind {
+	case nodes.KindNil:
+		return nil // TODO
+	case nodes.KindObject:
+		if typ := uast.TypeOf(n); typ != "" {
+			if i := strings.Index(typ, ":"); i >= 0 {
+				nd.tag = [2]string{typ[:i], typ[i+1:]}
+			} else {
+				nd.tag = [2]string{"", typ}
+			}
+		}
+		nd.obj, _ = nd.n.(nodes.ExternalObject)
+		nd.typ = objectNode
+		return wrap(nd)
+	case nodes.KindArray:
+		arr, _ := nd.n.(nodes.ExternalArray)
+		// array == sub nodes of this field
+		f := &node{
+			n: nd.n, kind: nd.kind,
+			typ: fieldNode, tag: [2]string{"", field},
+		}
+		if arr == nil {
+			f.sub = []*node{}
+			return f
+		}
+		sz := arr.Size()
+		f.sub = make([]*node, 0, sz)
+		for i := 0; i < sz; i++ {
+			v := arr.ValueAt(i)
+			s := toNode(v, "")
+			s.par = f
+			s.parInd = i
+			f.sub = append(f.sub, s)
+		}
+		return f
+	default:
+		// value
+		nd.typ = valueNode
+		return wrap(nd)
+	}
+}
+
+func (a *nodeNavigator) MoveToChild() bool {
+	switch a.cur.typ {
+	case rootNode:
+		// return the same node, but without the root type
+		n := toNode(a.cur.n, "")
+		if n == nil {
+			return false
+		}
+		n.par = a.cur
+		a.cur = n
+		return true
+	case objectNode:
+		// node is an object, children are wrapped into a tag with the name = field
+		if a.cur.obj == nil {
+			return false
+		}
+		cur := a.cur
+		if cur.sub == nil {
+			cur.loadChildren()
+		}
+		if len(cur.sub) == 0 {
+			return false
+		}
+		a.cur = cur.sub[0]
+		return true
+	case fieldNode:
+		if len(a.cur.sub) == 0 {
+			return false
+		}
+		n := a.cur.sub[0]
+		if n == nil {
+			return false
+		}
+		a.cur = n
+		return true
+	}
+	return false
+}
+
+func (a *nodeNavigator) isSub() bool {
+	return a.cur.par != nil && a.cur.parInd < len(a.cur.par.sub)
+}
+func (a *nodeNavigator) MoveToFirst() bool {
+	if a.isSub() {
+		par := a.cur.par
+		if n := par.sub[0]; n != nil {
+			a.cur = n
+		}
+	}
+	return true
+}
+
+func (a *nodeNavigator) MoveToNext() bool {
+	if a.isSub() {
+		par := a.cur.par
+		if i := a.cur.parInd + 1; i < len(par.sub) {
+			a.cur = par.sub[i]
+			return true
+		}
+	}
+	return false
+}
+
+func (a *nodeNavigator) MoveToPrevious() bool {
+	if a.isSub() {
+		par := a.cur.par
+		if i := a.cur.parInd - 1; i >= 0 && i < len(par.sub) {
+			a.cur = par.sub[i]
+			return true
+		}
+	}
+	return false
+}
+
+func (a *nodeNavigator) MoveTo(other xpath.NodeNavigator) bool {
+	node, ok := other.(*nodeNavigator)
+	if !ok || node.root != a.root {
+		return false
+	}
+	a.cur = node.cur
+	a.attri = node.attri
+	return true
+}

--- a/vendor/gopkg.in/bblfsh/sdk.v2/uast/query/xpath/xpath.go
+++ b/vendor/gopkg.in/bblfsh/sdk.v2/uast/query/xpath/xpath.go
@@ -1,0 +1,112 @@
+package xpath
+
+import (
+	"fmt"
+
+	"github.com/antchfx/xpath"
+
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+	"gopkg.in/bblfsh/sdk.v2/uast/query"
+)
+
+func New() query.Interface {
+	return &index{}
+}
+
+type index struct{}
+
+func (t *index) newNavigator(n nodes.External) xpath.NodeNavigator {
+	return newNavigator(n)
+}
+
+func (t *index) Prepare(query string) (query.Query, error) {
+	exp, err := xpath.Compile(query)
+	if err != nil {
+		return nil, err
+	}
+	return &xQuery{idx: t, exp: exp}, nil
+}
+
+func (t *index) Execute(root nodes.External, query string) (query.Iterator, error) {
+	q, err := t.Prepare(query)
+	if err != nil {
+		return nil, err
+	}
+	return q.Execute(root)
+}
+
+type xQuery struct {
+	idx *index
+	exp *xpath.Expr
+}
+
+func (q *xQuery) Execute(root nodes.External) (query.Iterator, error) {
+	nav := q.idx.newNavigator(root)
+	val := q.exp.Evaluate(nav)
+	if it, ok := val.(*xpath.NodeIterator); ok {
+		return &iterator{it: it}, nil
+	}
+	var v nodes.Value
+	switch val := val.(type) {
+	case bool:
+		v = nodes.Bool(val)
+	case float64:
+		if float64(int64(val)) == val {
+			v = nodes.Int(val)
+		} else {
+			v = nodes.Float(val)
+		}
+	case int:
+		v = nodes.Int(val)
+	case uint:
+		v = nodes.Uint(val)
+	case string:
+		v = nodes.String(val)
+	default:
+		return nil, fmt.Errorf("unsupported type: %T", val)
+	}
+	return &valIterator{val: v}, nil
+}
+
+type valIterator struct {
+	state int
+	val   nodes.Value
+}
+
+func (it *valIterator) Next() bool {
+	switch it.state {
+	case 0:
+		it.state++
+		return true
+	case 1:
+		it.state++
+	}
+	return false
+}
+
+func (it *valIterator) Node() nodes.External {
+	if it.state == 1 {
+		return it.val
+	}
+	return nil
+}
+
+type iterator struct {
+	it *xpath.NodeIterator
+}
+
+func (it *iterator) Next() bool {
+	return it.it.MoveNext()
+}
+
+func (it *iterator) Node() nodes.External {
+	c := it.it.Current()
+	if c == nil {
+		return nil
+	}
+	nav := c.(*nodeNavigator)
+	if nav.cur == nil {
+		return nil
+	}
+	return nav.cur.n
+}

--- a/vendor/gopkg.in/bblfsh/sdk.v2/uast/yaml/uastyml.go
+++ b/vendor/gopkg.in/bblfsh/sdk.v2/uast/yaml/uastyml.go
@@ -1,0 +1,333 @@
+package uastyml
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"gopkg.in/bblfsh/sdk.v2/uast"
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+	"gopkg.in/yaml.v2"
+)
+
+func Marshal(n nodes.Node) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	enc := NewEncoder(buf)
+	if err := enc.Encode(n); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+const (
+	tab  = "   "
+	null = "~"
+)
+
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{w: bufio.NewWriter(w)}
+}
+
+type Encoder struct {
+	w   *bufio.Writer
+	err error
+}
+
+func (enc *Encoder) Encode(n nodes.Node) error {
+	enc.marshal(nil, n, false)
+	if enc.err != nil {
+		return enc.err
+	}
+	return enc.w.Flush()
+}
+
+func (enc *Encoder) marshal(tabs []byte, n nodes.Node, field bool) {
+	switch n := n.(type) {
+	case nil:
+		enc.writeString(null)
+	case nodes.Object:
+		enc.writeObject(tabs, n)
+	case nodes.Array:
+		enc.writeArray(tabs, n)
+	case nodes.Value:
+		enc.writeValue(n, field)
+	default:
+		enc.err = fmt.Errorf("unexpected type: %T", n)
+	}
+}
+
+func (enc *Encoder) writeObject(tabs []byte, m nodes.Object) {
+	if len(m) == 0 {
+		enc.writeString("{}")
+		return
+	}
+	enc.writeString("{")
+	written := make(map[string]struct{})
+
+	ntabs := append(tabs, []byte(tab)...)
+	writeSysKey := func(s string, tab bool) {
+		if tab {
+			enc.writeString("\n")
+			enc.write(ntabs)
+		}
+		written[s] = struct{}{}
+		enc.marshalString(s, false)
+		enc.writeString(": ")
+	}
+
+	typ := ""
+	if v, ok := m[uast.KeyType].(nodes.String); ok {
+		enc.writeString(" ")
+		writeSysKey(uast.KeyType, false)
+		enc.marshalString(string(v), true)
+		enc.writeString(",")
+		typ = string(v)
+	}
+	if v, ok := m[uast.KeyToken].(nodes.Value); ok {
+		writeSysKey(uast.KeyToken, true)
+		enc.writeValue(v, true)
+		enc.writeString(",")
+	}
+	if v := uast.RolesOf(m); len(v) != 0 {
+		writeSysKey(uast.KeyRoles, true)
+		sort.Slice(v, func(i, j int) bool {
+			return v[i].String() < v[j].String()
+		})
+		enc.writeArray(ntabs, uast.RoleList(v...))
+		enc.writeString(",")
+	}
+	// enforce specific sorting for known types
+	emitObj := func(key string) {
+		if v, ok := m[key].(nodes.Object); ok {
+			writeSysKey(key, true)
+			enc.marshal(ntabs, v, true)
+			enc.writeString(",")
+		}
+	}
+	emitInt := func(key string) {
+		if v, ok := m[key].(nodes.Int); ok {
+			writeSysKey(key, true)
+			enc.marshal(ntabs, v, true)
+			enc.writeString(",")
+		} else if v, ok := m[key].(nodes.Uint); ok {
+			writeSysKey(key, true)
+			enc.marshal(ntabs, v, true)
+			enc.writeString(",")
+		}
+	}
+	switch typ {
+	case uast.TypePositions:
+		emitObj(uast.KeyStart)
+		emitObj(uast.KeyEnd)
+	case uast.TypePosition:
+		emitInt(uast.KeyPosOff)
+		emitInt(uast.KeyPosLine)
+		emitInt(uast.KeyPosCol)
+	default:
+		emitObj(uast.KeyPos)
+	}
+	for _, k := range m.Keys() {
+		if _, ok := written[k]; ok {
+			continue
+		}
+		v := m[k]
+		enc.writeString("\n")
+		enc.write(ntabs)
+		enc.marshalString(k, false)
+		enc.writeString(": ")
+		enc.marshal(ntabs, v, true)
+		enc.writeString(",")
+	}
+	enc.writeString("\n")
+	enc.write(tabs)
+	enc.writeString("}")
+}
+
+func (enc *Encoder) writeArray(tabs []byte, m nodes.Array) {
+	if len(m) == 0 {
+		enc.writeString("[]")
+		return
+	}
+	small := true
+	for _, o := range m {
+		if _, ok := o.(nodes.Value); !ok {
+			small = false
+			break
+		}
+	}
+	enc.writeString("[")
+	ntabs := append(tabs, []byte(tab)...)
+	if !small {
+		enc.writeString("\n")
+		enc.write(tabs)
+	}
+	for i, o := range m {
+		if small {
+			if i != 0 {
+				enc.writeString(", ")
+			}
+		} else {
+			enc.writeString(tab)
+		}
+		enc.marshal(ntabs, o, false)
+		if !small {
+			enc.writeString(",\n")
+			enc.write(tabs)
+		}
+	}
+	enc.writeString("]")
+}
+
+func (enc *Encoder) writeValue(v nodes.Value, field bool) {
+	switch v := v.(type) {
+	case nil:
+		enc.writeString(null)
+	case nodes.String:
+		enc.marshalString(string(v), field)
+	case nodes.Bool:
+		if v {
+			enc.writeString("true")
+		} else {
+			enc.writeString("false")
+		}
+	case nodes.Int:
+		enc.writeInt(int64(v))
+	case nodes.Uint:
+		enc.writeUint(uint64(v))
+	case nodes.Float:
+		enc.writeFloat(float64(v))
+	default:
+		enc.err = fmt.Errorf("unexpected type: %T", v)
+	}
+}
+func (enc *Encoder) marshalString(s string, field bool) {
+	var kind stringFormat
+	if field {
+		kind = stringDoubleQuoted
+	} else {
+		kind = bestStringFormat(s)
+	}
+	switch kind {
+	case stringPlain:
+		// do nothing
+	case stringQuoted:
+		s = "'" + strings.Replace(s, "'", "''", -1) + "'"
+	case stringDoubleQuoted:
+		fallthrough
+	default:
+		s = strconv.Quote(s)
+	}
+	enc.writeString(s)
+}
+
+func (enc *Encoder) write(data []byte) {
+	if enc.err != nil {
+		return
+	}
+	_, enc.err = enc.w.Write(data)
+}
+
+func (enc *Encoder) writeString(s string) {
+	if enc.err != nil {
+		return
+	}
+	_, enc.err = enc.w.WriteString(s)
+}
+
+func (enc *Encoder) writeInt(v int64) {
+	if enc.err != nil {
+		return
+	}
+	data := strconv.FormatInt(v, 10)
+	_, enc.err = enc.w.WriteString(data)
+}
+
+func (enc *Encoder) writeUint(v uint64) {
+	if enc.err != nil {
+		return
+	}
+	data := strconv.FormatUint(v, 10)
+	_, enc.err = enc.w.WriteString(data)
+}
+
+func (enc *Encoder) writeFloat(v float64) {
+	if enc.err != nil {
+		return
+	}
+	data := strconv.FormatFloat(v, 'g', -1, 64)
+	_, enc.err = enc.w.WriteString(data)
+}
+
+func (enc *Encoder) printf(format string, args ...interface{}) {
+	if enc.err != nil {
+		return
+	}
+	_, enc.err = fmt.Fprintf(enc.w, format, args...)
+}
+
+type stringFormat int
+
+const (
+	stringDoubleQuoted = stringFormat(iota)
+	stringQuoted
+	stringPlain
+)
+
+func bestStringFormat(s string) stringFormat {
+	letters := true
+	for _, r := range s {
+		if !unicode.IsPrint(r) {
+			return stringDoubleQuoted
+		} else if !unicode.IsLetter(r) {
+			letters = false
+		}
+	}
+	if !letters {
+		return stringQuoted
+	}
+	if len(s) <= 5 {
+		switch l := strings.ToLower(s); l {
+		// http://yaml.org/type/null.html
+		case "null", "~":
+			return stringQuoted
+		// http://yaml.org/type/bool.html
+		case "true", "yes", "y", "on",
+			"false", "no", "n", "off":
+			return stringQuoted
+		// http://yaml.org/type/merge.html
+		case "<<":
+			return stringQuoted
+		}
+	}
+	return stringPlain
+}
+
+func Unmarshal(data []byte) (nodes.Node, error) {
+	var o interface{}
+	if err := yaml.Unmarshal(data, &o); err != nil {
+		return nil, err
+	}
+	var fix func(interface{}) interface{}
+	fix = func(o interface{}) interface{} {
+		switch o := o.(type) {
+		case map[interface{}]interface{}:
+			m := make(map[string]interface{}, len(o))
+			for k, v := range o {
+				m[k.(string)] = fix(v)
+			}
+			return m
+		case []interface{}:
+			for i := range o {
+				o[i] = fix(o[i])
+			}
+		}
+		return o
+	}
+	o = fix(o)
+	return uast.ToNode(o)
+}

--- a/vendor/gopkg.in/yaml.v2/.travis.yml
+++ b/vendor/gopkg.in/yaml.v2/.travis.yml
@@ -4,6 +4,9 @@ go:
     - 1.4
     - 1.5
     - 1.6
+    - 1.7
+    - 1.8
+    - 1.9
     - tip
 
 go_import_path: gopkg.in/yaml.v2

--- a/vendor/gopkg.in/yaml.v2/LICENSE
+++ b/vendor/gopkg.in/yaml.v2/LICENSE
@@ -1,13 +1,201 @@
-Copyright 2011-2016 Canonical Ltd.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-    http://www.apache.org/licenses/LICENSE-2.0
+   1. Definitions.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/gopkg.in/yaml.v2/NOTICE
+++ b/vendor/gopkg.in/yaml.v2/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2011-2016 Canonical Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/gopkg.in/yaml.v2/README.md
+++ b/vendor/gopkg.in/yaml.v2/README.md
@@ -65,6 +65,8 @@ b:
   d: [3, 4]
 `
 
+// Note: struct fields must be public in order for unmarshal to
+// correctly populate the data.
 type T struct {
         A string
         B struct {

--- a/vendor/gopkg.in/yaml.v2/decode.go
+++ b/vendor/gopkg.in/yaml.v2/decode.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"math"
 	"reflect"
 	"strconv"
@@ -22,19 +23,22 @@ type node struct {
 	kind         int
 	line, column int
 	tag          string
-	value        string
-	implicit     bool
-	children     []*node
-	anchors      map[string]*node
+	// For an alias node, alias holds the resolved alias.
+	alias    *node
+	value    string
+	implicit bool
+	children []*node
+	anchors  map[string]*node
 }
 
 // ----------------------------------------------------------------------------
 // Parser, produces a node tree out of a libyaml event stream.
 
 type parser struct {
-	parser yaml_parser_t
-	event  yaml_event_t
-	doc    *node
+	parser   yaml_parser_t
+	event    yaml_event_t
+	doc      *node
+	doneInit bool
 }
 
 func newParser(b []byte) *parser {
@@ -42,19 +46,28 @@ func newParser(b []byte) *parser {
 	if !yaml_parser_initialize(&p.parser) {
 		panic("failed to initialize YAML emitter")
 	}
-
 	if len(b) == 0 {
 		b = []byte{'\n'}
 	}
-
 	yaml_parser_set_input_string(&p.parser, b)
-
-	p.skip()
-	if p.event.typ != yaml_STREAM_START_EVENT {
-		panic("expected stream start event, got " + strconv.Itoa(int(p.event.typ)))
-	}
-	p.skip()
 	return &p
+}
+
+func newParserFromReader(r io.Reader) *parser {
+	p := parser{}
+	if !yaml_parser_initialize(&p.parser) {
+		panic("failed to initialize YAML emitter")
+	}
+	yaml_parser_set_input_reader(&p.parser, r)
+	return &p
+}
+
+func (p *parser) init() {
+	if p.doneInit {
+		return
+	}
+	p.expect(yaml_STREAM_START_EVENT)
+	p.doneInit = true
 }
 
 func (p *parser) destroy() {
@@ -64,16 +77,35 @@ func (p *parser) destroy() {
 	yaml_parser_delete(&p.parser)
 }
 
-func (p *parser) skip() {
-	if p.event.typ != yaml_NO_EVENT {
-		if p.event.typ == yaml_STREAM_END_EVENT {
-			failf("attempted to go past the end of stream; corrupted value?")
+// expect consumes an event from the event stream and
+// checks that it's of the expected type.
+func (p *parser) expect(e yaml_event_type_t) {
+	if p.event.typ == yaml_NO_EVENT {
+		if !yaml_parser_parse(&p.parser, &p.event) {
+			p.fail()
 		}
-		yaml_event_delete(&p.event)
+	}
+	if p.event.typ == yaml_STREAM_END_EVENT {
+		failf("attempted to go past the end of stream; corrupted value?")
+	}
+	if p.event.typ != e {
+		p.parser.problem = fmt.Sprintf("expected %s event but got %s", e, p.event.typ)
+		p.fail()
+	}
+	yaml_event_delete(&p.event)
+	p.event.typ = yaml_NO_EVENT
+}
+
+// peek peeks at the next event in the event stream,
+// puts the results into p.event and returns the event type.
+func (p *parser) peek() yaml_event_type_t {
+	if p.event.typ != yaml_NO_EVENT {
+		return p.event.typ
 	}
 	if !yaml_parser_parse(&p.parser, &p.event) {
 		p.fail()
 	}
+	return p.event.typ
 }
 
 func (p *parser) fail() {
@@ -81,6 +113,10 @@ func (p *parser) fail() {
 	var line int
 	if p.parser.problem_mark.line != 0 {
 		line = p.parser.problem_mark.line
+		// Scanner errors don't iterate line before returning error
+		if p.parser.error == yaml_SCANNER_ERROR {
+			line++
+		}
 	} else if p.parser.context_mark.line != 0 {
 		line = p.parser.context_mark.line
 	}
@@ -103,7 +139,8 @@ func (p *parser) anchor(n *node, anchor []byte) {
 }
 
 func (p *parser) parse() *node {
-	switch p.event.typ {
+	p.init()
+	switch p.peek() {
 	case yaml_SCALAR_EVENT:
 		return p.scalar()
 	case yaml_ALIAS_EVENT:
@@ -118,7 +155,7 @@ func (p *parser) parse() *node {
 		// Happens when attempting to decode an empty buffer.
 		return nil
 	default:
-		panic("attempted to parse unknown event: " + strconv.Itoa(int(p.event.typ)))
+		panic("attempted to parse unknown event: " + p.event.typ.String())
 	}
 }
 
@@ -134,19 +171,20 @@ func (p *parser) document() *node {
 	n := p.node(documentNode)
 	n.anchors = make(map[string]*node)
 	p.doc = n
-	p.skip()
+	p.expect(yaml_DOCUMENT_START_EVENT)
 	n.children = append(n.children, p.parse())
-	if p.event.typ != yaml_DOCUMENT_END_EVENT {
-		panic("expected end of document event but got " + strconv.Itoa(int(p.event.typ)))
-	}
-	p.skip()
+	p.expect(yaml_DOCUMENT_END_EVENT)
 	return n
 }
 
 func (p *parser) alias() *node {
 	n := p.node(aliasNode)
 	n.value = string(p.event.anchor)
-	p.skip()
+	n.alias = p.doc.anchors[n.value]
+	if n.alias == nil {
+		failf("unknown anchor '%s' referenced", n.value)
+	}
+	p.expect(yaml_ALIAS_EVENT)
 	return n
 }
 
@@ -156,29 +194,29 @@ func (p *parser) scalar() *node {
 	n.tag = string(p.event.tag)
 	n.implicit = p.event.implicit
 	p.anchor(n, p.event.anchor)
-	p.skip()
+	p.expect(yaml_SCALAR_EVENT)
 	return n
 }
 
 func (p *parser) sequence() *node {
 	n := p.node(sequenceNode)
 	p.anchor(n, p.event.anchor)
-	p.skip()
-	for p.event.typ != yaml_SEQUENCE_END_EVENT {
+	p.expect(yaml_SEQUENCE_START_EVENT)
+	for p.peek() != yaml_SEQUENCE_END_EVENT {
 		n.children = append(n.children, p.parse())
 	}
-	p.skip()
+	p.expect(yaml_SEQUENCE_END_EVENT)
 	return n
 }
 
 func (p *parser) mapping() *node {
 	n := p.node(mappingNode)
 	p.anchor(n, p.event.anchor)
-	p.skip()
-	for p.event.typ != yaml_MAPPING_END_EVENT {
+	p.expect(yaml_MAPPING_START_EVENT)
+	for p.peek() != yaml_MAPPING_END_EVENT {
 		n.children = append(n.children, p.parse(), p.parse())
 	}
-	p.skip()
+	p.expect(yaml_MAPPING_END_EVENT)
 	return n
 }
 
@@ -187,7 +225,7 @@ func (p *parser) mapping() *node {
 
 type decoder struct {
 	doc     *node
-	aliases map[string]bool
+	aliases map[*node]bool
 	mapType reflect.Type
 	terrors []string
 	strict  bool
@@ -198,11 +236,13 @@ var (
 	durationType   = reflect.TypeOf(time.Duration(0))
 	defaultMapType = reflect.TypeOf(map[interface{}]interface{}{})
 	ifaceType      = defaultMapType.Elem()
+	timeType       = reflect.TypeOf(time.Time{})
+	ptrTimeType    = reflect.TypeOf(&time.Time{})
 )
 
 func newDecoder(strict bool) *decoder {
 	d := &decoder{mapType: defaultMapType, strict: strict}
-	d.aliases = make(map[string]bool)
+	d.aliases = make(map[*node]bool)
 	return d
 }
 
@@ -251,7 +291,7 @@ func (d *decoder) callUnmarshaler(n *node, u Unmarshaler) (good bool) {
 //
 // If n holds a null value, prepare returns before doing anything.
 func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unmarshaled, good bool) {
-	if n.tag == yaml_NULL_TAG || n.kind == scalarNode && n.tag == "" && (n.value == "null" || n.value == "" && n.implicit) {
+	if n.tag == yaml_NULL_TAG || n.kind == scalarNode && n.tag == "" && (n.value == "null" || n.value == "~" || n.value == "" && n.implicit) {
 		return out, false, false
 	}
 	again := true
@@ -308,16 +348,13 @@ func (d *decoder) document(n *node, out reflect.Value) (good bool) {
 }
 
 func (d *decoder) alias(n *node, out reflect.Value) (good bool) {
-	an, ok := d.doc.anchors[n.value]
-	if !ok {
-		failf("unknown anchor '%s' referenced", n.value)
-	}
-	if d.aliases[n.value] {
+	if d.aliases[n] {
+		// TODO this could actually be allowed in some circumstances.
 		failf("anchor '%s' value contains itself", n.value)
 	}
-	d.aliases[n.value] = true
-	good = d.unmarshal(an, out)
-	delete(d.aliases, n.value)
+	d.aliases[n] = true
+	good = d.unmarshal(n.alias, out)
+	delete(d.aliases, n)
 	return good
 }
 
@@ -329,7 +366,7 @@ func resetMap(out reflect.Value) {
 	}
 }
 
-func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
+func (d *decoder) scalar(n *node, out reflect.Value) bool {
 	var tag string
 	var resolved interface{}
 	if n.tag == "" && !n.implicit {
@@ -353,9 +390,26 @@ func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
 		}
 		return true
 	}
-	if s, ok := resolved.(string); ok && out.CanAddr() {
-		if u, ok := out.Addr().Interface().(encoding.TextUnmarshaler); ok {
-			err := u.UnmarshalText([]byte(s))
+	if resolvedv := reflect.ValueOf(resolved); out.Type() == resolvedv.Type() {
+		// We've resolved to exactly the type we want, so use that.
+		out.Set(resolvedv)
+		return true
+	}
+	// Perhaps we can use the value as a TextUnmarshaler to
+	// set its value.
+	if out.CanAddr() {
+		u, ok := out.Addr().Interface().(encoding.TextUnmarshaler)
+		if ok {
+			var text []byte
+			if tag == yaml_BINARY_TAG {
+				text = []byte(resolved.(string))
+			} else {
+				// We let any value be unmarshaled into TextUnmarshaler.
+				// That might be more lax than we'd like, but the
+				// TextUnmarshaler itself should bowl out any dubious values.
+				text = []byte(n.value)
+			}
+			err := u.UnmarshalText(text)
 			if err != nil {
 				fail(err)
 			}
@@ -366,46 +420,54 @@ func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
 	case reflect.String:
 		if tag == yaml_BINARY_TAG {
 			out.SetString(resolved.(string))
-			good = true
-		} else if resolved != nil {
+			return true
+		}
+		if resolved != nil {
 			out.SetString(n.value)
-			good = true
+			return true
 		}
 	case reflect.Interface:
 		if resolved == nil {
 			out.Set(reflect.Zero(out.Type()))
+		} else if tag == yaml_TIMESTAMP_TAG {
+			// It looks like a timestamp but for backward compatibility
+			// reasons we set it as a string, so that code that unmarshals
+			// timestamp-like values into interface{} will continue to
+			// see a string and not a time.Time.
+			// TODO(v3) Drop this.
+			out.Set(reflect.ValueOf(n.value))
 		} else {
 			out.Set(reflect.ValueOf(resolved))
 		}
-		good = true
+		return true
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		switch resolved := resolved.(type) {
 		case int:
 			if !out.OverflowInt(int64(resolved)) {
 				out.SetInt(int64(resolved))
-				good = true
+				return true
 			}
 		case int64:
 			if !out.OverflowInt(resolved) {
 				out.SetInt(resolved)
-				good = true
+				return true
 			}
 		case uint64:
 			if resolved <= math.MaxInt64 && !out.OverflowInt(int64(resolved)) {
 				out.SetInt(int64(resolved))
-				good = true
+				return true
 			}
 		case float64:
 			if resolved <= math.MaxInt64 && !out.OverflowInt(int64(resolved)) {
 				out.SetInt(int64(resolved))
-				good = true
+				return true
 			}
 		case string:
 			if out.Type() == durationType {
 				d, err := time.ParseDuration(resolved)
 				if err == nil {
 					out.SetInt(int64(d))
-					good = true
+					return true
 				}
 			}
 		}
@@ -414,44 +476,49 @@ func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
 		case int:
 			if resolved >= 0 && !out.OverflowUint(uint64(resolved)) {
 				out.SetUint(uint64(resolved))
-				good = true
+				return true
 			}
 		case int64:
 			if resolved >= 0 && !out.OverflowUint(uint64(resolved)) {
 				out.SetUint(uint64(resolved))
-				good = true
+				return true
 			}
 		case uint64:
 			if !out.OverflowUint(uint64(resolved)) {
 				out.SetUint(uint64(resolved))
-				good = true
+				return true
 			}
 		case float64:
 			if resolved <= math.MaxUint64 && !out.OverflowUint(uint64(resolved)) {
 				out.SetUint(uint64(resolved))
-				good = true
+				return true
 			}
 		}
 	case reflect.Bool:
 		switch resolved := resolved.(type) {
 		case bool:
 			out.SetBool(resolved)
-			good = true
+			return true
 		}
 	case reflect.Float32, reflect.Float64:
 		switch resolved := resolved.(type) {
 		case int:
 			out.SetFloat(float64(resolved))
-			good = true
+			return true
 		case int64:
 			out.SetFloat(float64(resolved))
-			good = true
+			return true
 		case uint64:
 			out.SetFloat(float64(resolved))
-			good = true
+			return true
 		case float64:
 			out.SetFloat(resolved)
-			good = true
+			return true
+		}
+	case reflect.Struct:
+		if resolvedv := reflect.ValueOf(resolved); out.Type() == resolvedv.Type() {
+			out.Set(resolvedv)
+			return true
 		}
 	case reflect.Ptr:
 		if out.Type().Elem() == reflect.TypeOf(resolved) {
@@ -459,13 +526,11 @@ func (d *decoder) scalar(n *node, out reflect.Value) (good bool) {
 			elem := reflect.New(out.Type().Elem())
 			elem.Elem().Set(reflect.ValueOf(resolved))
 			out.Set(elem)
-			good = true
+			return true
 		}
 	}
-	if !good {
-		d.terror(n, tag, out)
-	}
-	return good
+	d.terror(n, tag, out)
+	return false
 }
 
 func settableValueOf(i interface{}) reflect.Value {
@@ -482,6 +547,10 @@ func (d *decoder) sequence(n *node, out reflect.Value) (good bool) {
 	switch out.Kind() {
 	case reflect.Slice:
 		out.Set(reflect.MakeSlice(out.Type(), l, l))
+	case reflect.Array:
+		if l != out.Len() {
+			failf("invalid array: want %d elements but got %d", out.Len(), l)
+		}
 	case reflect.Interface:
 		// No type hints. Will have to use a generic sequence.
 		iface = out
@@ -500,7 +569,9 @@ func (d *decoder) sequence(n *node, out reflect.Value) (good bool) {
 			j++
 		}
 	}
-	out.Set(out.Slice(0, j))
+	if out.Kind() != reflect.Array {
+		out.Set(out.Slice(0, j))
+	}
 	if iface.IsValid() {
 		iface.Set(out)
 	}
@@ -561,12 +632,20 @@ func (d *decoder) mapping(n *node, out reflect.Value) (good bool) {
 			}
 			e := reflect.New(et).Elem()
 			if d.unmarshal(n.children[i+1], e) {
-				out.SetMapIndex(k, e)
+				d.setMapIndex(n.children[i+1], out, k, e)
 			}
 		}
 	}
 	d.mapType = mapType
 	return true
+}
+
+func (d *decoder) setMapIndex(n *node, out, k, v reflect.Value) {
+	if d.strict && out.MapIndex(k) != zeroValue {
+		d.terrors = append(d.terrors, fmt.Sprintf("line %d: key %#v already set in map", n.line+1, k.Interface()))
+		return
+	}
+	out.SetMapIndex(k, v)
 }
 
 func (d *decoder) mappingSlice(n *node, out reflect.Value) (good bool) {
@@ -616,6 +695,10 @@ func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
 		elemType = inlineMap.Type().Elem()
 	}
 
+	var doneFields []bool
+	if d.strict {
+		doneFields = make([]bool, len(sinfo.FieldsList))
+	}
 	for i := 0; i < l; i += 2 {
 		ni := n.children[i]
 		if isMerge(ni) {
@@ -626,6 +709,13 @@ func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
 			continue
 		}
 		if info, ok := sinfo.FieldsMap[name.String()]; ok {
+			if d.strict {
+				if doneFields[info.Id] {
+					d.terrors = append(d.terrors, fmt.Sprintf("line %d: field %s already set in type %s", ni.line+1, name.String(), out.Type()))
+					continue
+				}
+				doneFields[info.Id] = true
+			}
 			var field reflect.Value
 			if info.Inline == nil {
 				field = out.Field(info.Num)
@@ -639,9 +729,9 @@ func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
 			}
 			value := reflect.New(elemType).Elem()
 			d.unmarshal(n.children[i+1], value)
-			inlineMap.SetMapIndex(name, value)
+			d.setMapIndex(n.children[i+1], inlineMap, name, value)
 		} else if d.strict {
-			d.terrors = append(d.terrors, fmt.Sprintf("line %d: field %s not found in struct %s", n.line+1, name.String(), out.Type()))
+			d.terrors = append(d.terrors, fmt.Sprintf("line %d: field %s not found in type %s", ni.line+1, name.String(), out.Type()))
 		}
 	}
 	return true

--- a/vendor/gopkg.in/yaml.v2/emitterc.go
+++ b/vendor/gopkg.in/yaml.v2/emitterc.go
@@ -2,6 +2,7 @@ package yaml
 
 import (
 	"bytes"
+	"fmt"
 )
 
 // Flush the buffer if needed.
@@ -664,7 +665,7 @@ func yaml_emitter_emit_node(emitter *yaml_emitter_t, event *yaml_event_t,
 		return yaml_emitter_emit_mapping_start(emitter, event)
 	default:
 		return yaml_emitter_set_emitter_error(emitter,
-			"expected SCALAR, SEQUENCE-START, MAPPING-START, or ALIAS")
+			fmt.Sprintf("expected SCALAR, SEQUENCE-START, MAPPING-START, or ALIAS, but got %v", event.typ))
 	}
 }
 
@@ -842,7 +843,7 @@ func yaml_emitter_select_scalar_style(emitter *yaml_emitter_t, event *yaml_event
 	return true
 }
 
-// Write an achor.
+// Write an anchor.
 func yaml_emitter_process_anchor(emitter *yaml_emitter_t) bool {
 	if emitter.anchor_data.anchor == nil {
 		return true
@@ -994,10 +995,10 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 		break_space    = false
 		space_break    = false
 
-		preceeded_by_whitespace = false
-		followed_by_whitespace  = false
-		previous_space          = false
-		previous_break          = false
+		preceded_by_whitespace = false
+		followed_by_whitespace = false
+		previous_space         = false
+		previous_break         = false
 	)
 
 	emitter.scalar_data.value = value
@@ -1016,7 +1017,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 		flow_indicators = true
 	}
 
-	preceeded_by_whitespace = true
+	preceded_by_whitespace = true
 	for i, w := 0, 0; i < len(value); i += w {
 		w = width(value[i])
 		followed_by_whitespace = i+w >= len(value) || is_blank(value, i+w)
@@ -1047,7 +1048,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 					block_indicators = true
 				}
 			case '#':
-				if preceeded_by_whitespace {
+				if preceded_by_whitespace {
 					flow_indicators = true
 					block_indicators = true
 				}
@@ -1088,7 +1089,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 		}
 
 		// [Go]: Why 'z'? Couldn't be the end of the string as that's the loop condition.
-		preceeded_by_whitespace = is_blankz(value, i)
+		preceded_by_whitespace = is_blankz(value, i)
 	}
 
 	emitter.scalar_data.multiline = line_breaks

--- a/vendor/gopkg.in/yaml.v2/encode.go
+++ b/vendor/gopkg.in/yaml.v2/encode.go
@@ -3,12 +3,14 @@ package yaml
 import (
 	"encoding"
 	"fmt"
+	"io"
 	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 type encoder struct {
@@ -16,25 +18,39 @@ type encoder struct {
 	event   yaml_event_t
 	out     []byte
 	flow    bool
+	// doneInit holds whether the initial stream_start_event has been
+	// emitted.
+	doneInit bool
 }
 
-func newEncoder() (e *encoder) {
-	e = &encoder{}
-	e.must(yaml_emitter_initialize(&e.emitter))
+func newEncoder() *encoder {
+	e := &encoder{}
+	yaml_emitter_initialize(&e.emitter)
 	yaml_emitter_set_output_string(&e.emitter, &e.out)
 	yaml_emitter_set_unicode(&e.emitter, true)
-	e.must(yaml_stream_start_event_initialize(&e.event, yaml_UTF8_ENCODING))
-	e.emit()
-	e.must(yaml_document_start_event_initialize(&e.event, nil, nil, true))
-	e.emit()
 	return e
 }
 
-func (e *encoder) finish() {
-	e.must(yaml_document_end_event_initialize(&e.event, true))
+func newEncoderWithWriter(w io.Writer) *encoder {
+	e := &encoder{}
+	yaml_emitter_initialize(&e.emitter)
+	yaml_emitter_set_output_writer(&e.emitter, w)
+	yaml_emitter_set_unicode(&e.emitter, true)
+	return e
+}
+
+func (e *encoder) init() {
+	if e.doneInit {
+		return
+	}
+	yaml_stream_start_event_initialize(&e.event, yaml_UTF8_ENCODING)
 	e.emit()
+	e.doneInit = true
+}
+
+func (e *encoder) finish() {
 	e.emitter.open_ended = false
-	e.must(yaml_stream_end_event_initialize(&e.event))
+	yaml_stream_end_event_initialize(&e.event)
 	e.emit()
 }
 
@@ -44,9 +60,7 @@ func (e *encoder) destroy() {
 
 func (e *encoder) emit() {
 	// This will internally delete the e.event value.
-	if !yaml_emitter_emit(&e.emitter, &e.event) && e.event.typ != yaml_DOCUMENT_END_EVENT && e.event.typ != yaml_STREAM_END_EVENT {
-		e.must(false)
-	}
+	e.must(yaml_emitter_emit(&e.emitter, &e.event))
 }
 
 func (e *encoder) must(ok bool) {
@@ -59,13 +73,28 @@ func (e *encoder) must(ok bool) {
 	}
 }
 
+func (e *encoder) marshalDoc(tag string, in reflect.Value) {
+	e.init()
+	yaml_document_start_event_initialize(&e.event, nil, nil, true)
+	e.emit()
+	e.marshal(tag, in)
+	yaml_document_end_event_initialize(&e.event, true)
+	e.emit()
+}
+
 func (e *encoder) marshal(tag string, in reflect.Value) {
-	if !in.IsValid() {
+	if !in.IsValid() || in.Kind() == reflect.Ptr && in.IsNil() {
 		e.nilv()
 		return
 	}
 	iface := in.Interface()
-	if m, ok := iface.(Marshaler); ok {
+	switch m := iface.(type) {
+	case time.Time, *time.Time:
+		// Although time.Time implements TextMarshaler,
+		// we don't want to treat it as a string for YAML
+		// purposes because YAML has special support for
+		// timestamps.
+	case Marshaler:
 		v, err := m.MarshalYAML()
 		if err != nil {
 			fail(err)
@@ -75,31 +104,34 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 			return
 		}
 		in = reflect.ValueOf(v)
-	} else if m, ok := iface.(encoding.TextMarshaler); ok {
+	case encoding.TextMarshaler:
 		text, err := m.MarshalText()
 		if err != nil {
 			fail(err)
 		}
 		in = reflect.ValueOf(string(text))
+	case nil:
+		e.nilv()
+		return
 	}
 	switch in.Kind() {
 	case reflect.Interface:
-		if in.IsNil() {
-			e.nilv()
-		} else {
-			e.marshal(tag, in.Elem())
-		}
+		e.marshal(tag, in.Elem())
 	case reflect.Map:
 		e.mapv(tag, in)
 	case reflect.Ptr:
-		if in.IsNil() {
-			e.nilv()
+		if in.Type() == ptrTimeType {
+			e.timev(tag, in.Elem())
 		} else {
 			e.marshal(tag, in.Elem())
 		}
 	case reflect.Struct:
-		e.structv(tag, in)
-	case reflect.Slice:
+		if in.Type() == timeType {
+			e.timev(tag, in)
+		} else {
+			e.structv(tag, in)
+		}
+	case reflect.Slice, reflect.Array:
 		if in.Type().Elem() == mapItemType {
 			e.itemsv(tag, in)
 		} else {
@@ -191,10 +223,10 @@ func (e *encoder) mappingv(tag string, f func()) {
 		e.flow = false
 		style = yaml_FLOW_MAPPING_STYLE
 	}
-	e.must(yaml_mapping_start_event_initialize(&e.event, nil, []byte(tag), implicit, style))
+	yaml_mapping_start_event_initialize(&e.event, nil, []byte(tag), implicit, style)
 	e.emit()
 	f()
-	e.must(yaml_mapping_end_event_initialize(&e.event))
+	yaml_mapping_end_event_initialize(&e.event)
 	e.emit()
 }
 
@@ -240,23 +272,36 @@ var base60float = regexp.MustCompile(`^[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+(?:\.[0
 func (e *encoder) stringv(tag string, in reflect.Value) {
 	var style yaml_scalar_style_t
 	s := in.String()
-	rtag, rs := resolve("", s)
-	if rtag == yaml_BINARY_TAG {
-		if tag == "" || tag == yaml_STR_TAG {
-			tag = rtag
-			s = rs.(string)
-		} else if tag == yaml_BINARY_TAG {
+	canUsePlain := true
+	switch {
+	case !utf8.ValidString(s):
+		if tag == yaml_BINARY_TAG {
 			failf("explicitly tagged !!binary data must be base64-encoded")
-		} else {
+		}
+		if tag != "" {
 			failf("cannot marshal invalid UTF-8 data as %s", shortTag(tag))
 		}
+		// It can't be encoded directly as YAML so use a binary tag
+		// and encode it as base64.
+		tag = yaml_BINARY_TAG
+		s = encodeBase64(s)
+	case tag == "":
+		// Check to see if it would resolve to a specific
+		// tag when encoded unquoted. If it doesn't,
+		// there's no need to quote it.
+		rtag, _ := resolve("", s)
+		canUsePlain = rtag == yaml_STR_TAG && !isBase60Float(s)
 	}
-	if tag == "" && (rtag != yaml_STR_TAG || isBase60Float(s)) {
-		style = yaml_DOUBLE_QUOTED_SCALAR_STYLE
-	} else if strings.Contains(s, "\n") {
+	// Note: it's possible for user code to emit invalid YAML
+	// if they explicitly specify a tag and a string containing
+	// text that's incompatible with that tag.
+	switch {
+	case strings.Contains(s, "\n"):
 		style = yaml_LITERAL_SCALAR_STYLE
-	} else {
+	case canUsePlain:
 		style = yaml_PLAIN_SCALAR_STYLE
+	default:
+		style = yaml_DOUBLE_QUOTED_SCALAR_STYLE
 	}
 	e.emitScalar(s, "", tag, style)
 }
@@ -281,9 +326,20 @@ func (e *encoder) uintv(tag string, in reflect.Value) {
 	e.emitScalar(s, "", tag, yaml_PLAIN_SCALAR_STYLE)
 }
 
+func (e *encoder) timev(tag string, in reflect.Value) {
+	t := in.Interface().(time.Time)
+	s := t.Format(time.RFC3339Nano)
+	e.emitScalar(s, "", tag, yaml_PLAIN_SCALAR_STYLE)
+}
+
 func (e *encoder) floatv(tag string, in reflect.Value) {
-	// FIXME: Handle 64 bits here.
-	s := strconv.FormatFloat(float64(in.Float()), 'g', -1, 32)
+	// Issue #352: When formatting, use the precision of the underlying value
+	precision := 64
+	if in.Kind() == reflect.Float32 {
+		precision = 32
+	}
+
+	s := strconv.FormatFloat(in.Float(), 'g', -1, precision)
 	switch s {
 	case "+Inf":
 		s = ".inf"

--- a/vendor/gopkg.in/yaml.v2/go.mod
+++ b/vendor/gopkg.in/yaml.v2/go.mod
@@ -1,0 +1,5 @@
+module "gopkg.in/yaml.v2"
+
+require (
+	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
+)

--- a/vendor/gopkg.in/yaml.v2/readerc.go
+++ b/vendor/gopkg.in/yaml.v2/readerc.go
@@ -93,9 +93,18 @@ func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 		panic("read handler must be set")
 	}
 
+	// [Go] This function was changed to guarantee the requested length size at EOF.
+	// The fact we need to do this is pretty awful, but the description above implies
+	// for that to be the case, and there are tests
+
 	// If the EOF flag is set and the raw buffer is empty, do nothing.
 	if parser.eof && parser.raw_buffer_pos == len(parser.raw_buffer) {
-		return true
+		// [Go] ACTUALLY! Read the documentation of this function above.
+		// This is just broken. To return true, we need to have the
+		// given length in the buffer. Not doing that means every single
+		// check that calls this function to make sure the buffer has a
+		// given length is Go) panicking; or C) accessing invalid memory.
+		//return true
 	}
 
 	// Return if the buffer contains enough characters.
@@ -388,6 +397,15 @@ func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 			parser.unread++
 			break
 		}
+	}
+	// [Go] Read the documentation of this function above. To return true,
+	// we need to have the given length in the buffer. Not doing that means
+	// every single check that calls this function to make sure the buffer
+	// has a given length is Go) panicking; or C) accessing invalid memory.
+	// This happens here due to the EOF above breaking early.
+	for buffer_len < length {
+		parser.buffer[buffer_len] = 0
+		buffer_len++
 	}
 	parser.buffer = parser.buffer[:buffer_len]
 	return true

--- a/vendor/gopkg.in/yaml.v2/resolve.go
+++ b/vendor/gopkg.in/yaml.v2/resolve.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"unicode/utf8"
+	"time"
 )
 
 type resolveMapItem struct {
@@ -75,7 +75,7 @@ func longTag(tag string) string {
 
 func resolvableTag(tag string) bool {
 	switch tag {
-	case "", yaml_STR_TAG, yaml_BOOL_TAG, yaml_INT_TAG, yaml_FLOAT_TAG, yaml_NULL_TAG:
+	case "", yaml_STR_TAG, yaml_BOOL_TAG, yaml_INT_TAG, yaml_FLOAT_TAG, yaml_NULL_TAG, yaml_TIMESTAMP_TAG:
 		return true
 	}
 	return false
@@ -92,6 +92,19 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 		switch tag {
 		case "", rtag, yaml_STR_TAG, yaml_BINARY_TAG:
 			return
+		case yaml_FLOAT_TAG:
+			if rtag == yaml_INT_TAG {
+				switch v := out.(type) {
+				case int64:
+					rtag = yaml_FLOAT_TAG
+					out = float64(v)
+					return
+				case int:
+					rtag = yaml_FLOAT_TAG
+					out = float64(v)
+					return
+				}
+			}
 		}
 		failf("cannot decode %s `%s` as a %s", shortTag(rtag), in, shortTag(tag))
 	}()
@@ -125,6 +138,15 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 
 		case 'D', 'S':
 			// Int, float, or timestamp.
+			// Only try values as a timestamp if the value is unquoted or there's an explicit
+			// !!timestamp tag.
+			if tag == "" || tag == yaml_TIMESTAMP_TAG {
+				t, ok := parseTimestamp(in)
+				if ok {
+					return yaml_TIMESTAMP_TAG, t
+				}
+			}
+
 			plain := strings.Replace(in, "_", "", -1)
 			intv, err := strconv.ParseInt(plain, 0, 64)
 			if err == nil {
@@ -158,28 +180,20 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 					return yaml_INT_TAG, uintv
 				}
 			} else if strings.HasPrefix(plain, "-0b") {
-				intv, err := strconv.ParseInt(plain[3:], 2, 64)
+				intv, err := strconv.ParseInt("-"+plain[3:], 2, 64)
 				if err == nil {
-					if intv == int64(int(intv)) {
-						return yaml_INT_TAG, -int(intv)
+					if true || intv == int64(int(intv)) {
+						return yaml_INT_TAG, int(intv)
 					} else {
-						return yaml_INT_TAG, -intv
+						return yaml_INT_TAG, intv
 					}
 				}
 			}
-			// XXX Handle timestamps here.
-
 		default:
 			panic("resolveTable item not yet handled: " + string(rune(hint)) + " (with " + in + ")")
 		}
 	}
-	if tag == yaml_BINARY_TAG {
-		return yaml_BINARY_TAG, in
-	}
-	if utf8.ValidString(in) {
-		return yaml_STR_TAG, in
-	}
-	return yaml_BINARY_TAG, encodeBase64(in)
+	return yaml_STR_TAG, in
 }
 
 // encodeBase64 encodes s as base64 that is broken up into multiple lines
@@ -205,4 +219,40 @@ func encodeBase64(s string) string {
 		}
 	}
 	return string(out[:k])
+}
+
+// This is a subset of the formats allowed by the regular expression
+// defined at http://yaml.org/type/timestamp.html.
+var allowedTimestampFormats = []string{
+	"2006-1-2T15:4:5.999999999Z07:00", // RCF3339Nano with short date fields.
+	"2006-1-2t15:4:5.999999999Z07:00", // RFC3339Nano with short date fields and lower-case "t".
+	"2006-1-2 15:4:5.999999999",       // space separated with no time zone
+	"2006-1-2",                        // date only
+	// Notable exception: time.Parse cannot handle: "2001-12-14 21:59:43.10 -5"
+	// from the set of examples.
+}
+
+// parseTimestamp parses s as a timestamp string and
+// returns the timestamp and reports whether it succeeded.
+// Timestamp formats are defined at http://yaml.org/type/timestamp.html
+func parseTimestamp(s string) (time.Time, bool) {
+	// TODO write code to check all the formats supported by
+	// http://yaml.org/type/timestamp.html instead of using time.Parse.
+
+	// Quick check: all date formats start with YYYY-.
+	i := 0
+	for ; i < len(s); i++ {
+		if c := s[i]; c < '0' || c > '9' {
+			break
+		}
+	}
+	if i != 4 || i == len(s) || s[i] != '-' {
+		return time.Time{}, false
+	}
+	for _, format := range allowedTimestampFormats {
+		if t, err := time.Parse(format, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
 }

--- a/vendor/gopkg.in/yaml.v2/scannerc.go
+++ b/vendor/gopkg.in/yaml.v2/scannerc.go
@@ -611,7 +611,7 @@ func yaml_parser_set_scanner_tag_error(parser *yaml_parser_t, directive bool, co
 	if directive {
 		context = "while parsing a %TAG directive"
 	}
-	return yaml_parser_set_scanner_error(parser, context, context_mark, "did not find URI escaped octet")
+	return yaml_parser_set_scanner_error(parser, context, context_mark, problem)
 }
 
 func trace(args ...interface{}) func() {
@@ -870,12 +870,6 @@ func yaml_parser_save_simple_key(parser *yaml_parser_t) bool {
 	// level.
 
 	required := parser.flow_level == 0 && parser.indent == parser.mark.column
-
-	// A simple key is required only when it is the first token in the current
-	// line.  Therefore it is always allowed.  But we add a check anyway.
-	if required && !parser.simple_key_allowed {
-		panic("should not happen")
-	}
 
 	//
 	// If the current position may start a simple key, save it.
@@ -1944,7 +1938,7 @@ func yaml_parser_scan_tag_handle(parser *yaml_parser_t, directive bool, start_ma
 	} else {
 		// It's either the '!' tag or not really a tag handle.  If it's a %TAG
 		// directive, it's an error.  If it's a tag token, it must be a part of URI.
-		if directive && !(s[0] == '!' && s[1] == 0) {
+		if directive && string(s) != "!" {
 			yaml_parser_set_scanner_tag_error(parser, directive,
 				start_mark, "did not find expected '!'")
 			return false
@@ -1959,6 +1953,7 @@ func yaml_parser_scan_tag_handle(parser *yaml_parser_t, directive bool, start_ma
 func yaml_parser_scan_tag_uri(parser *yaml_parser_t, directive bool, head []byte, start_mark yaml_mark_t, uri *[]byte) bool {
 	//size_t length = head ? strlen((char *)head) : 0
 	var s []byte
+	hasTag := len(head) > 0
 
 	// Copy the head if needed.
 	//
@@ -2000,10 +1995,10 @@ func yaml_parser_scan_tag_uri(parser *yaml_parser_t, directive bool, head []byte
 		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
 			return false
 		}
+		hasTag = true
 	}
 
-	// Check if the tag is non-empty.
-	if len(s) == 0 {
+	if !hasTag {
 		yaml_parser_set_scanner_tag_error(parser, directive,
 			start_mark, "did not find expected tag URI")
 		return false
@@ -2474,6 +2469,10 @@ func yaml_parser_scan_flow_scalar(parser *yaml_parser_t, token *yaml_token_t, si
 			}
 		}
 
+		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
+			return false
+		}
+
 		// Check if we are at the end of the scalar.
 		if single {
 			if parser.buffer[parser.buffer_pos] == '\'' {
@@ -2486,10 +2485,6 @@ func yaml_parser_scan_flow_scalar(parser *yaml_parser_t, token *yaml_token_t, si
 		}
 
 		// Consume blank characters.
-		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
-			return false
-		}
-
 		for is_blank(parser.buffer, parser.buffer_pos) || is_break(parser.buffer, parser.buffer_pos) {
 			if is_blank(parser.buffer, parser.buffer_pos) {
 				// Consume a space or a tab character.
@@ -2591,19 +2586,10 @@ func yaml_parser_scan_plain_scalar(parser *yaml_parser_t, token *yaml_token_t) b
 		// Consume non-blank characters.
 		for !is_blankz(parser.buffer, parser.buffer_pos) {
 
-			// Check for 'x:x' in the flow context. TODO: Fix the test "spec-08-13".
-			if parser.flow_level > 0 &&
-				parser.buffer[parser.buffer_pos] == ':' &&
-				!is_blankz(parser.buffer, parser.buffer_pos+1) {
-				yaml_parser_set_scanner_error(parser, "while scanning a plain scalar",
-					start_mark, "found unexpected ':'")
-				return false
-			}
-
 			// Check for indicators that may end a plain scalar.
 			if (parser.buffer[parser.buffer_pos] == ':' && is_blankz(parser.buffer, parser.buffer_pos+1)) ||
 				(parser.flow_level > 0 &&
-					(parser.buffer[parser.buffer_pos] == ',' || parser.buffer[parser.buffer_pos] == ':' ||
+					(parser.buffer[parser.buffer_pos] == ',' ||
 						parser.buffer[parser.buffer_pos] == '?' || parser.buffer[parser.buffer_pos] == '[' ||
 						parser.buffer[parser.buffer_pos] == ']' || parser.buffer[parser.buffer_pos] == '{' ||
 						parser.buffer[parser.buffer_pos] == '}')) {
@@ -2655,10 +2641,10 @@ func yaml_parser_scan_plain_scalar(parser *yaml_parser_t, token *yaml_token_t) b
 		for is_blank(parser.buffer, parser.buffer_pos) || is_break(parser.buffer, parser.buffer_pos) {
 			if is_blank(parser.buffer, parser.buffer_pos) {
 
-				// Check for tab character that abuse indentation.
+				// Check for tab characters that abuse indentation.
 				if leading_blanks && parser.mark.column < indent && is_tab(parser.buffer, parser.buffer_pos) {
 					yaml_parser_set_scanner_error(parser, "while scanning a plain scalar",
-						start_mark, "found a tab character that violate indentation")
+						start_mark, "found a tab character that violates indentation")
 					return false
 				}
 

--- a/vendor/gopkg.in/yaml.v2/sorter.go
+++ b/vendor/gopkg.in/yaml.v2/sorter.go
@@ -51,6 +51,15 @@ func (l keyList) Less(i, j int) bool {
 		}
 		var ai, bi int
 		var an, bn int64
+		if ar[i] == '0' || br[i] == '0' {
+			for j := i - 1; j >= 0 && unicode.IsDigit(ar[j]); j-- {
+				if ar[j] != '0' {
+					an = 1
+					bn = 1
+					break
+				}
+			}
+		}
 		for ai = i; ai < len(ar) && unicode.IsDigit(ar[ai]); ai++ {
 			an = an*10 + int64(ar[ai]-'0')
 		}

--- a/vendor/gopkg.in/yaml.v2/writerc.go
+++ b/vendor/gopkg.in/yaml.v2/writerc.go
@@ -18,72 +18,9 @@ func yaml_emitter_flush(emitter *yaml_emitter_t) bool {
 		return true
 	}
 
-	// If the output encoding is UTF-8, we don't need to recode the buffer.
-	if emitter.encoding == yaml_UTF8_ENCODING {
-		if err := emitter.write_handler(emitter, emitter.buffer[:emitter.buffer_pos]); err != nil {
-			return yaml_emitter_set_writer_error(emitter, "write error: "+err.Error())
-		}
-		emitter.buffer_pos = 0
-		return true
-	}
-
-	// Recode the buffer into the raw buffer.
-	var low, high int
-	if emitter.encoding == yaml_UTF16LE_ENCODING {
-		low, high = 0, 1
-	} else {
-		high, low = 1, 0
-	}
-
-	pos := 0
-	for pos < emitter.buffer_pos {
-		// See the "reader.c" code for more details on UTF-8 encoding.  Note
-		// that we assume that the buffer contains a valid UTF-8 sequence.
-
-		// Read the next UTF-8 character.
-		octet := emitter.buffer[pos]
-
-		var w int
-		var value rune
-		switch {
-		case octet&0x80 == 0x00:
-			w, value = 1, rune(octet&0x7F)
-		case octet&0xE0 == 0xC0:
-			w, value = 2, rune(octet&0x1F)
-		case octet&0xF0 == 0xE0:
-			w, value = 3, rune(octet&0x0F)
-		case octet&0xF8 == 0xF0:
-			w, value = 4, rune(octet&0x07)
-		}
-		for k := 1; k < w; k++ {
-			octet = emitter.buffer[pos+k]
-			value = (value << 6) + (rune(octet) & 0x3F)
-		}
-		pos += w
-
-		// Write the character.
-		if value < 0x10000 {
-			var b [2]byte
-			b[high] = byte(value >> 8)
-			b[low] = byte(value & 0xFF)
-			emitter.raw_buffer = append(emitter.raw_buffer, b[0], b[1])
-		} else {
-			// Write the character using a surrogate pair (check "reader.c").
-			var b [4]byte
-			value -= 0x10000
-			b[high] = byte(0xD8 + (value >> 18))
-			b[low] = byte((value >> 10) & 0xFF)
-			b[high+2] = byte(0xDC + ((value >> 8) & 0xFF))
-			b[low+2] = byte(value & 0xFF)
-			emitter.raw_buffer = append(emitter.raw_buffer, b[0], b[1], b[2], b[3])
-		}
-	}
-
-	// Write the raw buffer.
-	if err := emitter.write_handler(emitter, emitter.raw_buffer); err != nil {
+	if err := emitter.write_handler(emitter, emitter.buffer[:emitter.buffer_pos]); err != nil {
 		return yaml_emitter_set_writer_error(emitter, "write error: "+err.Error())
 	}
 	emitter.buffer_pos = 0
-	emitter.raw_buffer = emitter.raw_buffer[:0]
 	return true
 }

--- a/vendor/gopkg.in/yaml.v2/yamlh.go
+++ b/vendor/gopkg.in/yaml.v2/yamlh.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"fmt"
 	"io"
 )
 
@@ -238,6 +239,27 @@ const (
 	yaml_MAPPING_START_EVENT  // A MAPPING-START event.
 	yaml_MAPPING_END_EVENT    // A MAPPING-END event.
 )
+
+var eventStrings = []string{
+	yaml_NO_EVENT:             "none",
+	yaml_STREAM_START_EVENT:   "stream start",
+	yaml_STREAM_END_EVENT:     "stream end",
+	yaml_DOCUMENT_START_EVENT: "document start",
+	yaml_DOCUMENT_END_EVENT:   "document end",
+	yaml_ALIAS_EVENT:          "alias",
+	yaml_SCALAR_EVENT:         "scalar",
+	yaml_SEQUENCE_START_EVENT: "sequence start",
+	yaml_SEQUENCE_END_EVENT:   "sequence end",
+	yaml_MAPPING_START_EVENT:  "mapping start",
+	yaml_MAPPING_END_EVENT:    "mapping end",
+}
+
+func (e yaml_event_type_t) String() string {
+	if e < 0 || int(e) >= len(eventStrings) {
+		return fmt.Sprintf("unknown event %d", e)
+	}
+	return eventStrings[e]
+}
 
 // The event structure.
 type yaml_event_t struct {
@@ -508,7 +530,7 @@ type yaml_parser_t struct {
 
 	problem string // Error description.
 
-	// The byte about which the problem occured.
+	// The byte about which the problem occurred.
 	problem_offset int
 	problem_value  int
 	problem_mark   yaml_mark_t
@@ -521,9 +543,9 @@ type yaml_parser_t struct {
 
 	read_handler yaml_read_handler_t // Read handler.
 
-	input_file io.Reader // File input data.
-	input      []byte    // String input data.
-	input_pos  int
+	input_reader io.Reader // File input data.
+	input        []byte    // String input data.
+	input_pos    int
 
 	eof bool // EOF flag
 
@@ -632,7 +654,7 @@ type yaml_emitter_t struct {
 	write_handler yaml_write_handler_t // Write handler.
 
 	output_buffer *[]byte   // String output data.
-	output_file   io.Writer // File output data.
+	output_writer io.Writer // File output data.
 
 	buffer     []byte // The working buffer.
 	buffer_pos int    // The current position of the buffer.


### PR DESCRIPTION
Currently, the only way to talk to bblfshd is via gRPC API. This means that user needs to install one of our CLIs from one of the language clients in order to test it.

This PR adds a simple HTTP API for parsing files, listing supported languages and checking the version.

**Version:**
```
GET /api/v1/version
```
or
```sh
curl http://localhost:9480/api/v1/version
```

**Supported languages:**
```
GET /api/v1/languages
```
or
```sh
curl http://localhost:9480/api/v1/languages
```

**Parse a file:**
```
POST /api/v1/parse?lang=xxxx
Accept: application/json

<file content>
```
or
```sh
curl --data-binary @main.go -H 'Accept: application/json' 'http://localhost:9480/api/v1/parse?lang=go'
```

Supported formats for the parse response:
- `application/json`
- `application/x-yaml`
- `application/octet-stream` (our binary encoding)

Signed-off-by: Denys Smirnov <denys@sourced.tech>