### PR TITLE
bblfshd: hide parts that depend on Cgo

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,3 +1,5 @@
+// +build linux,cgo
+
 package daemon
 
 import (
@@ -10,15 +12,6 @@ import (
 	"google.golang.org/grpc"
 	protocol1 "gopkg.in/bblfsh/sdk.v1/protocol"
 	protocol2 "gopkg.in/bblfsh/sdk.v2/protocol"
-	"gopkg.in/src-d/go-errors.v1"
-)
-
-var (
-	ErrUnexpected        = errors.NewKind("unexpected error")
-	ErrMissingDriver     = errors.NewKind("missing driver for language %q")
-	ErrRuntime           = errors.NewKind("runtime failure")
-	ErrAlreadyInstalled  = protocol.ErrAlreadyInstalled
-	ErrLanguageDetection = errors.NewKind("could not autodetect language")
 )
 
 // Daemon is a Babelfish server.

--- a/daemon/driver.go
+++ b/daemon/driver.go
@@ -1,3 +1,5 @@
+// +build linux,cgo
+
 package daemon
 
 import (

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -1,0 +1,14 @@
+package daemon
+
+import (
+	"github.com/bblfsh/bblfshd/daemon/protocol"
+	"gopkg.in/src-d/go-errors.v1"
+)
+
+var (
+	ErrUnexpected        = errors.NewKind("unexpected error")
+	ErrMissingDriver     = errors.NewKind("missing driver for language %q")
+	ErrRuntime           = errors.NewKind("runtime failure")
+	ErrAlreadyInstalled  = protocol.ErrAlreadyInstalled
+	ErrLanguageDetection = errors.NewKind("could not autodetect language")
+)

--- a/daemon/pool.go
+++ b/daemon/pool.go
@@ -1,3 +1,5 @@
+// +build linux,cgo
+
 package daemon
 
 import (
@@ -11,6 +13,7 @@ import (
 	"github.com/bblfsh/bblfshd/daemon/protocol"
 
 	"context"
+
 	"github.com/sirupsen/logrus"
 	"gopkg.in/bblfsh/sdk.v1/sdk/server"
 	"gopkg.in/src-d/go-errors.v1"

--- a/daemon/service.go
+++ b/daemon/service.go
@@ -1,3 +1,5 @@
+// +build linux,cgo
+
 package daemon
 
 import (

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package runtime
 
 import (

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1,3 +1,5 @@
+// +build linux,cgo
+
 package runtime
 
 import (


### PR DESCRIPTION
There are parts of `bblfshd` binary that:
 - depend on linux kernel features
 - depend on C github.com/opencontainers/runc/libcontainer/nsenter
 - are not used anywhere in `bblfshctl`

This proposal hides those behind `linux & cgo` build flags.

This allows to run `make packages-internal` on non-linux OSes and build&cross-compile `bblfshctl` binary.

Test plan:
 - `make packages-internal`

