### PR TITLE
Fix for building release binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ VERSION ?= $(DEV_PREFIX)-$(GIT_COMMIT)$(GIT_DIRTY)
 
 # Go parameters
 GO_CMD = go
-GO_BUILD = $(GO_CMD) build -tags ostree
+GO_BUILD = $(GO_CMD) build
 GO_GET = $(GO_CMD) get -v
 GO_TEST = $(GO_CMD) test -v
 
@@ -161,7 +161,6 @@ push-drivers: build-drivers
 	fi;
 
 packages: dependencies docker-build
-	$(if $(pushdisabled),$(error $(pushdisabled)))
 	$(DOCKER_RUN) -v $(BUILD_PATH):/go/src/$(GO_PKG)/build \
 	                -e TRAVIS_BRANCH=$(TRAVIS_BRANCH) \
 	                -e TRAVIS_TAG=$(TRAVIS_TAG) \
@@ -174,7 +173,9 @@ $(COMMANDS):
 	for arch in $(PKG_ARCH); do \
 		for os in $(PKG_OS_$@); do \
 			mkdir -p $(BUILD_PATH)/$@_$${os}_$${arch}; \
-			GOOS=$${os} GOARCH=$${arch} $(GO_BUILD) \
+			echo ; \
+			echo "$${os} - $@"; \
+			GOOS=$${os} GOARCH=$${arch}  $(GO_BUILD) $$([ $${os} = "linux" ] && echo -tags ostree) \
 				--ldflags '$(LDFLAGS)' \
 				-o "$(BUILD_PATH)/$@_$${os}_$${arch}/$@" \
 				$(CMD_PATH)/$@/main.go; \

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,3 +1,5 @@
+// +build linux,cgo
+
 package daemon
 
 import (
@@ -10,15 +12,6 @@ import (
 	"google.golang.org/grpc"
 	protocol1 "gopkg.in/bblfsh/sdk.v1/protocol"
 	protocol2 "gopkg.in/bblfsh/sdk.v2/protocol"
-	"gopkg.in/src-d/go-errors.v1"
-)
-
-var (
-	ErrUnexpected        = errors.NewKind("unexpected error")
-	ErrMissingDriver     = errors.NewKind("missing driver for language %q")
-	ErrRuntime           = errors.NewKind("runtime failure")
-	ErrAlreadyInstalled  = protocol.ErrAlreadyInstalled
-	ErrLanguageDetection = errors.NewKind("could not autodetect language")
 )
 
 // Daemon is a Babelfish server.

--- a/daemon/driver.go
+++ b/daemon/driver.go
@@ -1,3 +1,5 @@
+// +build linux,cgo
+
 package daemon
 
 import (

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -1,0 +1,14 @@
+package daemon
+
+import (
+	"github.com/bblfsh/bblfshd/daemon/protocol"
+	"gopkg.in/src-d/go-errors.v1"
+)
+
+var (
+	ErrUnexpected        = errors.NewKind("unexpected error")
+	ErrMissingDriver     = errors.NewKind("missing driver for language %q")
+	ErrRuntime           = errors.NewKind("runtime failure")
+	ErrAlreadyInstalled  = protocol.ErrAlreadyInstalled
+	ErrLanguageDetection = errors.NewKind("could not autodetect language")
+)

--- a/daemon/pool.go
+++ b/daemon/pool.go
@@ -1,3 +1,5 @@
+// +build linux,cgo
+
 package daemon
 
 import (
@@ -11,6 +13,7 @@ import (
 	"github.com/bblfsh/bblfshd/daemon/protocol"
 
 	"context"
+
 	"github.com/sirupsen/logrus"
 	"gopkg.in/bblfsh/sdk.v1/sdk/server"
 	"gopkg.in/src-d/go-errors.v1"

--- a/daemon/service.go
+++ b/daemon/service.go
@@ -1,3 +1,5 @@
+// +build linux,cgo
+
 package daemon
 
 import (

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package runtime
 
 import (

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1,3 +1,5 @@
+// +build linux,cgo
+
 package runtime
 
 import (


### PR DESCRIPTION
Fixes #192. 

Based on #204 which should be merged first, so only 74f2cf8 needs to be reviewed here.

This PR:
 - adds debug output with binary/os that is being built
 - allows running `make packages` locally (reverts 261e96ec511656903ffa0773b673e2e1a8095f90)
 - conditionally applies `ostree` tag. 
   This allows to avoid failing builds of `bblfshctl` for OSes without Cgo cross-compilation support (darwin/windows). (go-ostree [depends on Cgo](https://github.com/ostreedev/ostree-go/tree/master/pkg/glibobject))

Test plan:
 - `make packages`