### PR TITLE
Deprecate v1 parsing protocol

### DIFF
--- a/daemon/driver.go
+++ b/daemon/driver.go
@@ -22,13 +22,20 @@ import (
 	protocol2 "gopkg.in/bblfsh/sdk.v2/protocol"
 )
 
+type ServiceV1 interface {
+	// SupportedLanguages uses DefaultService to process the given SupportedLanguagesRequest to get the supported drivers.
+	SupportedLanguages(ctx context.Context, in *protocol1.SupportedLanguagesRequest, opts ...grpc.CallOption) (*protocol1.SupportedLanguagesResponse, error)
+	// Version uses DefaultVersioner to process the given version request to get the version.
+	Version(ctx context.Context, in *protocol1.VersionRequest, opts ...grpc.CallOption) (*protocol1.VersionResponse, error)
+}
+
 type Driver interface {
 	ID() string
 	Start() error
 	Stop() error
 	Status() (protocol.Status, error)
 	State() (*protocol.DriverInstanceState, error)
-	Service() protocol1.ProtocolServiceClient
+	Service() ServiceV1
 	ServiceV2() protocol2.DriverClient
 }
 
@@ -194,7 +201,7 @@ func (i *DriverInstance) Stop() error {
 }
 
 // Service returns the client using the grpc connection.
-func (i *DriverInstance) Service() protocol1.ProtocolServiceClient {
+func (i *DriverInstance) Service() ServiceV1 {
 	return i.srv1
 }
 

--- a/daemon/service.go
+++ b/daemon/service.go
@@ -103,40 +103,10 @@ func NewService(d *Daemon) *Service {
 }
 
 func (d *Service) Parse(req *protocol1.ParseRequest) *protocol1.ParseResponse {
-	resp := &protocol1.ParseResponse{}
-	start := time.Now()
-	defer func() {
-		resp.Elapsed = time.Since(start)
-		d.logResponse(resp.Status, req.Filename, req.Language, len(req.Content), resp.Elapsed)
-	}()
-
-	if req.Content == "" {
-		logrus.Debugf("empty request received, returning empty UAST")
-		return resp
-	}
-
-	language, dp, err := d.selectPool(req.Language, req.Content, req.Filename)
-	if err != nil {
-		logrus.Errorf("error selecting pool: %s", err)
-		resp.Response = newResponseFromError(err)
-		resp.Language = language
-		return resp
-	}
-
-	req.Language = language
-
-	err = dp.Execute(func(driver Driver) error {
-		resp, err = driver.Service().Parse(context.Background(), req)
-		return err
-	}, req.Timeout)
-
-	if err != nil {
-		resp = &protocol1.ParseResponse{}
-		resp.Response = newResponseFromError(err)
-	}
-
-	resp.Language = language
-	return resp
+	var resp protocol1.ParseResponse
+	resp.Status = protocol1.Fatal
+	resp.Errors = []string{"v1 parsing protocol deprecated"}
+	return &resp
 }
 
 func (d *Service) logResponse(s protocol1.Status, filename string, language string, size int, elapsed time.Duration) {
@@ -163,39 +133,10 @@ func (d *Service) logResponse(s protocol1.Status, filename string, language stri
 }
 
 func (d *Service) NativeParse(req *protocol1.NativeParseRequest) *protocol1.NativeParseResponse {
-	resp := &protocol1.NativeParseResponse{}
-	start := time.Now()
-	defer func() {
-		resp.Elapsed = time.Since(start)
-		d.logResponse(resp.Status, req.Language, req.Language, len(req.Content), resp.Elapsed)
-	}()
-
-	if req.Content == "" {
-		logrus.Debugf("empty request received, returning empty AST")
-		return resp
-	}
-
-	language, dp, err := d.selectPool(req.Language, req.Content, req.Filename)
-	if err != nil {
-		logrus.Errorf("error selecting pool: %s", err)
-		resp.Response = newResponseFromError(err)
-		return resp
-	}
-
-	req.Language = language
-
-	err = dp.Execute(func(driver Driver) error {
-		resp, err = driver.Service().NativeParse(context.Background(), req)
-		return err
-	}, req.Timeout)
-
-	if err != nil {
-		resp = &protocol1.NativeParseResponse{}
-		resp.Response = newResponseFromError(err)
-	}
-
-	resp.Language = language
-	return resp
+	var resp protocol1.NativeParseResponse
+	resp.Status = protocol1.Fatal
+	resp.Errors = []string{"v1 parsing protocol deprecated"}
+	return &resp
 }
 
 func (s *Service) selectPool(language, content, filename string) (string, *DriverPool, error) {

--- a/daemon/service_test.go
+++ b/daemon/service_test.go
@@ -1,11 +1,16 @@
 package daemon
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/bblfsh/sdk.v1/protocol"
+
+	protocol1 "gopkg.in/bblfsh/sdk.v1/protocol"
+	protocol2 "gopkg.in/bblfsh/sdk.v2/protocol"
+	"gopkg.in/bblfsh/sdk.v2/uast"
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
 )
 
 func TestServiceParse(t *testing.T) {
@@ -14,26 +19,17 @@ func TestServiceParse(t *testing.T) {
 	d, tmp := buildMockedDaemon(t)
 	defer os.RemoveAll(tmp)
 
-	s := NewService(d)
-	resp := s.Parse(&protocol.ParseRequest{Filename: "foo.py", Content: "foo"})
-	require.Len(resp.Errors, 0)
-	require.Equal(resp.UAST.Token, "foo")
+	s := NewServiceV2(d)
+	resp, err := s.Parse(context.Background(), &protocol2.ParseRequest{
+		Filename: "foo.py", Content: "foo",
+	})
+	require.NoError(err)
+	ast, err := resp.Nodes()
+	require.NoError(err)
+	obj, ok := ast.(nodes.Object)
+	require.True(ok)
+	require.Equal("foo", uast.TokenOf(obj))
 	require.Equal(resp.Language, "python")
-	require.True(resp.Elapsed.Nanoseconds() > 0)
-}
-
-func TestServiceNativeParse(t *testing.T) {
-	require := require.New(t)
-
-	d, tmp := buildMockedDaemon(t)
-	defer os.RemoveAll(tmp)
-
-	s := NewService(d)
-	resp := s.NativeParse(&protocol.NativeParseRequest{Filename: "foo.py", Content: "foo"})
-	require.Len(resp.Errors, 0)
-	require.Equal(resp.AST, "foo")
-	require.Equal(resp.Language, "python")
-	require.True(resp.Elapsed.Nanoseconds() > 0)
 }
 
 func TestServiceVersion(t *testing.T) {
@@ -43,7 +39,7 @@ func TestServiceVersion(t *testing.T) {
 	defer os.RemoveAll(tmp)
 
 	s := NewService(d)
-	resp := s.Version(&protocol.VersionRequest{})
+	resp := s.Version(&protocol1.VersionRequest{})
 	require.Len(resp.Errors, 0)
 	require.Equal(resp.Version, "foo")
 }
@@ -79,7 +75,7 @@ func TestService_SupportedLanguages(t *testing.T) {
 	defer os.RemoveAll(tmp)
 
 	s := NewService(d)
-	languages := s.SupportedLanguages(&protocol.SupportedLanguagesRequest{})
+	languages := s.SupportedLanguages(&protocol1.SupportedLanguagesRequest{})
 	require.Len(languages.Errors, 0)
 	require.Len(languages.Languages, 2)
 


### PR DESCRIPTION
This PR will track a deprecation of v1 parsing protocol.

Note, that gRPC v1 protocol is still used to get a list of all languages and driver version info.

Support in clients:
- [x] Go (https://github.com/bblfsh/go-client/pull/86)
- [x] Python (https://github.com/bblfsh/client-python/pull/128)
- [x] Scala (https://github.com/bblfsh/client-scala/pull/76)

Signed-off-by: Denys Smirnov <denys@sourced.tech>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/bblfshd/210)
<!-- Reviewable:end -->
