### PR TITLE
bblfshctl: dedup CLI output on driver install

### DIFF
--- a/cmd/bblfshctl/cmd/driver_install.go
+++ b/cmd/bblfshctl/cmd/driver_install.go
@@ -174,6 +174,7 @@ func (c *DriverInstallCommand) installDrivers(refs []driverRef) error {
 	} else if len(refs) == 1 {
 		return c.installSingleDriver(refs[0])
 	}
+	refNum := len(refs)
 	ctx := context.Background()
 	const workers = 3
 	type resp struct {
@@ -230,7 +231,7 @@ func (c *DriverInstallCommand) installDrivers(refs []driverRef) error {
 	}
 
 	draining := false
-
+	first := true
 install:
 	for todo >= 0 {
 		clist = clist[:0]
@@ -240,6 +241,13 @@ install:
 		sort.Slice(clist, func(i, j int) bool {
 			return clist[i][0] < clist[j][0]
 		})
+
+		if first {
+			first = false
+		} else {
+			fmt.Print(fmt.Sprintf("\033[%dA", refNum+3)) //delete previous N lines in terminal
+			fmt.Print("\033[J")
+		}
 
 		if todo == 0 {
 			fmt.Printf("\nInstalled %d/%d drivers:\n", done, len(clist))
@@ -286,6 +294,8 @@ install:
 		for _, err := range errs {
 			fmt.Fprintln(os.Stderr, "error:", err)
 		}
+	} else {
+		fmt.Println("Done")
 	}
 	return last
 }


### PR DESCRIPTION
Fixes #196 

Before:
https://github.com/bblfsh/bblfshd/issues/196#issue-367099785

After:
```
$ bblfshctl driver install --recommended

Installed 8/8 drivers:
        bash  +  docker://bblfsh/bash-driver:latest
         cpp  +  docker://bblfsh/cpp-driver:latest
          go  +  docker://bblfsh/go-driver:latest
        java  +  docker://bblfsh/java-driver:latest
  javascript  +  docker://bblfsh/javascript-driver:latest
         php  +  docker://bblfsh/php-driver:latest
      python  +  docker://bblfsh/python-driver:latest
        ruby  +  docker://bblfsh/ruby-driver:latest

Done
```

Works only in terminal, e.g if re-directed to pipe would behave as before.