### PR TITLE
CI: enable usage of personal TravisCI accounts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ language: go
 go:
   - '1.10.x'
 
-sudo: required
+go_import_path: github.com/bblfsh/bblfshd
 
+sudo: required
 services:
   - docker
 


### PR DESCRIPTION
This would put files in the right place on personal CI accounts (like https://travis-ci.org/bzz/server) in $GOPATH.