### PR TITLE
Use client's context and don't force max timeout

### DIFF
--- a/daemon/pool_test.go
+++ b/daemon/pool_test.go
@@ -49,19 +49,7 @@ func TestDriverPoolExecute_Timeout(t *testing.T) {
 	})
 
 	err := dp.Execute(nil, time.Nanosecond)
-	require.True(ErrPoolTimeout.Is(err))
-}
-
-func TestDriverPoolExecute_InvalidTimeout(t *testing.T) {
-	require := require.New(t)
-
-	dp := NewDriverPool(func() (Driver, error) {
-		time.Sleep(time.Millisecond)
-		return newMockDriver()
-	})
-
-	err := dp.Execute(nil, 100*time.Minute)
-	require.True(ErrInvalidPoolTimeout.Is(err), "%T, %v", err, err)
+	require.True(err == context.DeadlineExceeded)
 }
 
 func TestDriverPoolState(t *testing.T) {


### PR DESCRIPTION
Currently `bblfshd` forces a timeout on the context to be 5 min at most. When doing batch processing, the client may send thousands of requests, saturating the pool. Depending on the size of source files, clients may hit a max timeout and they have no way to wait longer, even if they are willing to.

This change drops the maximal timeout and relies on the timeout provided by the client (via context). The deadline propagation works over gRPC, allowing clients to specify exactly what time they are willing to wait for the response.

If the deadline is not set, `bblfshd` will set it to a default value automatically, as before.

Fixes #227.

Signed-off-by: Denys Smirnov <denys@sourced.tech>