### PR TITLE
Fix build time on VersionResponse

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -663,6 +663,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "82de88ea9d692bb72c7eae1ef7b157ff1fe2ffc6da1a3fc364558fc154727f14"
+  inputs-digest = "58809bc080b0267b337a0bca7baf237636d7b1f794292adbf95f135d9166643f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/bblfshd/main.go
+++ b/cmd/bblfshd/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/bblfsh/bblfshd/daemon"
 	"github.com/bblfsh/bblfshd/runtime"
@@ -114,7 +115,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	d := daemon.NewDaemon(version, r, grpcOpts...)
+	parsedBuild, err := time.Parse(time.RFC3339, build)
+	if err != nil {
+		logrus.Errorf("wrong date format for build: %s", err)
+		os.Exit(1)
+	}
+	d := daemon.NewDaemon(version, parsedBuild, r, grpcOpts...)
 	if args := cmd.Args(); len(args) == 2 && args[0] == "install" && args[1] == "recommended" {
 		err := installRecommended(d)
 		if err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/bblfsh/bblfshd/daemon/protocol"
 	"github.com/bblfsh/bblfshd/runtime"
@@ -24,6 +25,7 @@ type Daemon struct {
 	ControlServer *grpc.Server
 
 	version   string
+	build     time.Time
 	runtime   *runtime.Runtime
 	driverEnv []string
 
@@ -32,12 +34,13 @@ type Daemon struct {
 }
 
 // NewDaemon creates a new server based on the runtime with the given version.
-func NewDaemon(version string, r *runtime.Runtime, opts ...grpc.ServerOption) *Daemon {
+func NewDaemon(version string, build time.Time, r *runtime.Runtime, opts ...grpc.ServerOption) *Daemon {
 	commonOpt := protocol2.ServerOptions()
 	opts = append(opts, commonOpt...)
 
 	d := &Daemon{
 		version:       version,
+		build:         build,
 		runtime:       r,
 		pool:          make(map[string]*DriverPool),
 		UserServer:    grpc.NewServer(opts...),

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -121,7 +121,9 @@ func buildMockedDaemon(t *testing.T, images ...runtime.DriverImage) (*Daemon, st
 		}
 	}
 
-	d := NewDaemon("foo", r)
+	bdate, err := time.Parse(time.RFC3339, "2019-01-28T16:49:06+01:00")
+	require.NoError(err)
+	d := NewDaemon("foo", bdate, r)
 
 	dp := NewDriverPool(func() (Driver, error) {
 		return newEchoDriver(), nil

--- a/daemon/service.go
+++ b/daemon/service.go
@@ -236,7 +236,7 @@ func (s *Service) selectPool(ctx context.Context, language, content, filename st
 }
 
 func (d *Service) Version(req *protocol1.VersionRequest) *protocol1.VersionResponse {
-	return &protocol1.VersionResponse{Version: d.daemon.version}
+	return &protocol1.VersionResponse{Version: d.daemon.version, Build: d.daemon.build}
 }
 
 func (d *Service) SupportedLanguages(req *protocol1.SupportedLanguagesRequest) *protocol1.SupportedLanguagesResponse {

--- a/daemon/service_test.go
+++ b/daemon/service_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/bblfsh/sdk.v1/protocol"
@@ -46,6 +47,10 @@ func TestServiceVersion(t *testing.T) {
 	resp := s.Version(&protocol.VersionRequest{})
 	require.Len(resp.Errors, 0)
 	require.Equal(resp.Version, "foo")
+
+	bdate, err := time.Parse(time.RFC3339, "2019-01-28T16:49:06+01:00")
+	require.NoError(err)
+	require.Equal(resp.Build, bdate)
 }
 
 func TestControlServiceDriverPoolStates(t *testing.T) {


### PR DESCRIPTION
Since it wasn't being loaded on `NewDaemon` on main (or elsewhere) the nice date 0001-01-01 was being sent by RPC.

Related to: bblfsh/client-python/issues/141

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>