### PR TITLE
Specify an exact date format for the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ BUILD_PATH := $(BASE_PATH)/build
 CMD_PATH := $(BASE_PATH)/cmd
 
 # Build information
-BUILD ?= $(shell date -Iseconds)
+BUILD ?= $(shell date +%FT%X%z)
 GIT_COMMIT=$(shell git rev-parse HEAD | cut -c1-7)
 GIT_DIRTY=$(shell test -n "`git status --porcelain`" && echo "-dirty" || true)
 DEV_PREFIX := dev
@@ -57,7 +57,7 @@ LDFLAGS = -X main.version=$(VERSION) -X main.build=$(BUILD)
 
 # Docker
 DOCKER_CMD = docker
-DOCKER_BUILD = $(DOCKER_CMD) build --build-arg BBLFSHD_VERSION=$(VERSION) --build-arg BBLFSHD_BUILD=$(BUILD)
+DOCKER_BUILD = $(DOCKER_CMD) build --build-arg BBLFSHD_VERSION=$(VERSION) --build-arg BBLFSHD_BUILD="$(BUILD)"
 DOCKER_RUN = $(DOCKER_CMD) run --rm
 DOCKER_BUILD_IMAGE = bblfshd-build
 DOCKER_TAG ?= $(DOCKER_CMD) tag

--- a/cmd/bblfshd/main.go
+++ b/cmd/bblfshd/main.go
@@ -115,7 +115,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	parsedBuild, err := time.Parse("2006-01-02T15:04:05-07:00", build)
+	parsedBuild, err := time.Parse("2006-01-02T15:04:05-0700", build)
 	if err != nil {
 		logrus.Errorf("wrong date format for build: %s", err)
 		os.Exit(1)


### PR DESCRIPTION
It looks like `date -Iseconds` is not portable - it gives different results locally and in CI.

This PR specifies an exact format that we expect.

Signed-off-by: Denys Smirnov <denys@sourced.tech>