### PR TITLE
Quote linker flags passed to the Go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ifneq ($(origin TRAVIS_TAG), undefined)
 endif
 
 # Build
-LDFLAGS = -X main.version=$(VERSION) -X main.build=$(BUILD)
+LDFLAGS = -X main.version=$(VERSION) -X main.build="$(BUILD)"
 
 # Docker
 DOCKER_CMD = docker


### PR DESCRIPTION
Because the "go build" invocation strips one layer of quoting, we need to ensure that any extra spaces in the argument list do not trigger spurious extra arguments to the underlying go tool link invocation.
