### PR TITLE
Fix quotations on build-time variable substitutions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,10 @@ RUN mkdir /build
 ARG BBLFSHD_VERSION=dev
 ARG BBLFSHD_BUILD=unknown
 
-ENV GO_LDFLAGS="-X main.version=${BBLFSHD_VERSION} -X main.build='${BBLFSHD_BUILD}'"
+ENV GO_LDFLAGS="-X 'main.version=${BBLFSHD_VERSION}' -X 'main.build=${BBLFSHD_BUILD}'"
 
-RUN go build  -tags ostree --ldflags "'${GO_LDFLAGS}'" -o /build/bblfshd ./cmd/bblfshd/
-RUN go build --ldflags "'${GO_LDFLAGS}'" -o /build/bblfshctl ./cmd/bblfshctl/
+RUN go build  -tags ostree --ldflags "${GO_LDFLAGS}" -o /build/bblfshd ./cmd/bblfshd/
+RUN go build --ldflags "${GO_LDFLAGS}" -o /build/bblfshctl ./cmd/bblfshctl/
 
 
 # Final image for bblfshd


### PR DESCRIPTION
Updates #243. Apparently the parser for -ldflags values is sensitive to where
quotations are inserted. That means my previous fixes were both partly right
and partly wrong. Here, we are able to drop one layer of quoting at the shell
level by moving the flag-level quotes further out.

I verified this locally with the bugged case from CI.