### PR TITLE
Fix the date rendering to sync between local & CI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ BUILD_PATH := $(BASE_PATH)/build
 CMD_PATH := $(BASE_PATH)/cmd
 
 # Build information
-BUILD ?= $(shell date +%FT%X%z)
+BUILD ?= $(shell date +%FT%H:%M:%S%z)
 GIT_COMMIT=$(shell git rev-parse HEAD | cut -c1-7)
 GIT_DIRTY=$(shell test -n "`git status --porcelain`" && echo "-dirty" || true)
 DEV_PREFIX := dev


### PR DESCRIPTION
Addresses part of #243. The `date` command in Travis's build image renders the
local time (%X) including an AM/PM marker and an extra space.  Since we want
HH:MM:SS specifically, rewrite the expression to use that explicitly.

Signed-off-by: M. J. Fromberger <michael.j.fromberger@gmail.com>