### PR TITLE
HotFix build date parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ $(COMMANDS):
 			echo ; \
 			echo "$${os} - $@"; \
 			GOOS=$${os} GOARCH=$${arch}  $(GO_BUILD) $$([ $${os} = "linux" ] && echo -tags ostree) \
-				--ldflags '$(LDFLAGS)' \
+				--ldflags "$(LDFLAGS)" \
 				-o "$(BUILD_PATH)/$@_$${os}_$${arch}/$@" \
 				$(CMD_PATH)/$@/main.go; \
 			cd $(BUILD_PATH); \

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ifneq ($(origin TRAVIS_TAG), undefined)
 endif
 
 # Build
-LDFLAGS = -X main.version=$(VERSION) -X main.build="$(BUILD)"
+LDFLAGS = -X main.version=$(VERSION) -X main.build=$(BUILD)
 
 # Docker
 DOCKER_CMD = docker

--- a/cmd/bblfshd/main.go
+++ b/cmd/bblfshd/main.go
@@ -22,9 +22,11 @@ import (
 	"gopkg.in/bblfsh/sdk.v2/driver/manifest/discovery"
 )
 
+const defaultBuild = "undefined"
+
 var (
 	version = "undefined"
-	build   = "undefined"
+	build   = defaultBuild
 
 	network        *string
 	address        *string
@@ -117,8 +119,13 @@ func main() {
 
 	parsedBuild, err := time.Parse(daemon.BuildDateFormat, build)
 	if err != nil {
-		logrus.Errorf("wrong date format for build: %s", err)
-		os.Exit(1)
+		logrus.Errorf("wrong date format for this build: %s", err)
+		if build == defaultBuild {
+			build = time.Now().Format(daemon.BuildDateFormat)
+			logrus.Infof("using start time instead in this dev build: %s", build)
+		} else {
+			os.Exit(1)
+		}
 	}
 	d := daemon.NewDaemon(version, parsedBuild, r, grpcOpts...)
 	if args := cmd.Args(); len(args) == 2 && args[0] == "install" && args[1] == "recommended" {

--- a/cmd/bblfshd/main.go
+++ b/cmd/bblfshd/main.go
@@ -22,7 +22,10 @@ import (
 	"gopkg.in/bblfsh/sdk.v2/driver/manifest/discovery"
 )
 
-const defaultBuild = "undefined"
+const (
+	defaultBuild    = "undefined"
+	buildDateFormat = "2006-01-02T15:04:05-0700"
+)
 
 var (
 	version = "undefined"
@@ -117,12 +120,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	parsedBuild, err := time.Parse(daemon.BuildDateFormat, build)
+	parsedBuild, err := time.Parse(buildDateFormat, build)
 	if err != nil {
 		if build == defaultBuild {
 			parsedBuild = time.Now()
 			logrus.Infof("using start time instead in this dev build: %s",
-				parsedBuild.Format(daemon.BuildDateFormat))
+				parsedBuild.Format(buildDateFormat))
 		} else {
 			logrus.Errorf("wrong date format for this build: %s", err)
 			os.Exit(1)

--- a/cmd/bblfshd/main.go
+++ b/cmd/bblfshd/main.go
@@ -119,11 +119,12 @@ func main() {
 
 	parsedBuild, err := time.Parse(daemon.BuildDateFormat, build)
 	if err != nil {
-		logrus.Errorf("wrong date format for this build: %s", err)
 		if build == defaultBuild {
-			build = time.Now().Format(daemon.BuildDateFormat)
-			logrus.Infof("using start time instead in this dev build: %s", build)
+			parsedBuild = time.Now()
+			logrus.Infof("using start time instead in this dev build: %s",
+				parsedBuild.Format(daemon.BuildDateFormat))
 		} else {
+			logrus.Errorf("wrong date format for this build: %s", err)
 			os.Exit(1)
 		}
 	}

--- a/cmd/bblfshd/main.go
+++ b/cmd/bblfshd/main.go
@@ -115,7 +115,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	parsedBuild, err := time.Parse("2006-01-02T15:04:05-0700", build)
+	parsedBuild, err := time.Parse(daemon.BuildDateFormat, build)
 	if err != nil {
 		logrus.Errorf("wrong date format for build: %s", err)
 		os.Exit(1)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -19,6 +19,8 @@ import (
 	protocol2 "gopkg.in/bblfsh/sdk.v2/protocol"
 )
 
+const BuildDateFormat = "2006-01-02T15:04:05-0700"
+
 // Daemon is a Babelfish server.
 type Daemon struct {
 	UserServer    *grpc.Server

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -19,8 +19,6 @@ import (
 	protocol2 "gopkg.in/bblfsh/sdk.v2/protocol"
 )
 
-const BuildDateFormat = "2006-01-02T15:04:05-0700"
-
 // Daemon is a Babelfish server.
 type Daemon struct {
 	UserServer    *grpc.Server

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/bblfsh/bblfshd/runtime"
 )
 
+// actual date format used in bblfshd is different
+const testBuildDate = "2019-01-28T16:49:06+01:00"
+
 func TestDaemonState(t *testing.T) {
 	require := require.New(t)
 
@@ -121,9 +124,8 @@ func buildMockedDaemon(t *testing.T, images ...runtime.DriverImage) (*Daemon, st
 		}
 	}
 
-	bdate, err := time.Parse(BuildDateFormat, "2019-01-28T16:49:06+0100")
-	require.NoError(err)
-	d := NewDaemon("foo", bdate, r)
+	parsedBuild, err := time.Parse(time.RFC3339, testBuildDate)
+	d := NewDaemon("foo", parsedBuild, r)
 
 	dp := NewDriverPool(func() (Driver, error) {
 		return newEchoDriver(), nil

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -121,7 +121,7 @@ func buildMockedDaemon(t *testing.T, images ...runtime.DriverImage) (*Daemon, st
 		}
 	}
 
-	bdate, err := time.Parse(time.RFC3339, "2019-01-28T16:49:06+01:00")
+	bdate, err := time.Parse(BuildDateFormat, "2019-01-28T16:49:06+0100")
 	require.NoError(err)
 	d := NewDaemon("foo", bdate, r)
 

--- a/daemon/service_test.go
+++ b/daemon/service_test.go
@@ -48,7 +48,7 @@ func TestServiceVersion(t *testing.T) {
 	require.Len(resp.Errors, 0)
 	require.Equal(resp.Version, "foo")
 
-	bdate, err := time.Parse(time.RFC3339, "2019-01-28T16:49:06+01:00")
+	bdate, err := time.Parse(time.RFC3339, testBuildDate)
 	require.NoError(err)
 	require.Equal(resp.Build, bdate)
 }


### PR DESCRIPTION
Fixes #247 (please read it for more context)

Consists of (see individual commits)
 - reverting #242 
 - small refactoring to unify date parsing
 - sync quotation \w `src-d/ci` as a standard
 - restoring `go build` workflow after #233