### PR TITLE
Fix multiple issues with a driver pool

### DIFF
--- a/daemon/common_test.go
+++ b/daemon/common_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -44,7 +45,7 @@ func (d *mockDriver) ServiceV2() protocol2.DriverClient {
 	return nil
 }
 
-func (d *mockDriver) Start() error {
+func (d *mockDriver) Start(ctx context.Context) error {
 	return nil
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -179,7 +179,7 @@ func (d *Daemon) newDriverPool(rctx context.Context, language string, image runt
 			return nil, err
 		}
 
-		if err := driver.Start(); err != nil {
+		if err := driver.Start(rctx); err != nil {
 			return nil, err
 		}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -191,8 +191,12 @@ func (d *Daemon) newDriverPool(rctx context.Context, language string, image runt
 		"language": language,
 	})
 
+	if err := dp.Start(); err != nil {
+		return nil, err
+	}
+
 	d.pool[language] = dp
-	return dp, dp.Start()
+	return dp, nil
 }
 
 func (d *Daemon) removePool(language string) error {

--- a/daemon/driver_test.go
+++ b/daemon/driver_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -32,7 +33,10 @@ func TestNewDriver(t *testing.T) {
 
 	require.NoError(err)
 
-	err = i.Start()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	err = i.Start(ctx)
 	require.NoError(err)
 
 	time.Sleep(50 * time.Millisecond)
@@ -60,7 +64,10 @@ func TestDriverInstance_State(t *testing.T) {
 	require.Len(state.Processes, 0)
 	require.True(state.Created.IsZero())
 
-	err = i.Start()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	err = i.Start(ctx)
 	require.NoError(err)
 	defer func() {
 		err = i.Stop()

--- a/daemon/pool_test.go
+++ b/daemon/pool_test.go
@@ -92,8 +92,10 @@ func TestDriverPoolExecute_Recovery(t *testing.T) {
 	err := dp.Start()
 	require.NoError(err)
 
+	ctx := context.Background()
+
 	for i := 0; i < 100; i++ {
-		err := dp.Execute(func(_ context.Context, d Driver) error {
+		err := dp.ExecuteCtx(ctx, func(_ context.Context, d Driver) error {
 			require.NotNil(d)
 
 			if i%10 == 0 {
@@ -101,7 +103,7 @@ func TestDriverPoolExecute_Recovery(t *testing.T) {
 			}
 
 			return nil
-		}, 0)
+		})
 
 		require.Nil(err)
 		require.Len(dp.Current(), 1)


### PR DESCRIPTION
This PR fixes multiple issues found while addressing the timeout issue in C# driver: https://github.com/bblfsh/csharp-driver/issues/25

The issue was caused by a combination of factors:

1) `bblfshd` was limiting the timeout for driver startup to 5 sec. So the first request will always timeout if the driver init takes longer, and there is no way for the client to change it. It was fixed by passing the context directly.

2) If the first request failed, `bblfshd` was setting the driver pool anyway, and it become broken since no one returns the failed driver back to the queue. This caused a deadlock for any consequent requests. Fixed by not setting the pool/queue on error.

3) Maximal gRPC backoff delay was set too high, leading to unnecessary delay when driver takes more time to init. Fixed by capping the delay to 1 sec (it will retry).

This should fix the https://github.com/bblfsh/csharp-driver/issues/25, although the container startup may still take up to 5-6 sec. This is a startup time of the container itself, even before the driver gets a chance to execute. Need to check what may be the reason for this.

Few more issue were discovered along the way:

4) Failed driver was not shutdown properly. May have caused other issues in `bblfshd`. Fixed by stopping the container on the error path.

5) `bblfshd` was not acquiring the pool lock then shutting down. This may have caused data races with clients sending parse requests. Fixed by acquiring the lock.

Also, this PR includes few more changes:

1) Mutex for the driver pools was changed to RW to allow multiple callers to use an driver existing pool if it was already initialized.

2) `bblfshd` now supports a `--pprof` flag to expose a pprof HTTP endpoint. Useful to find deadlock, profile, etc.