### PR TITLE
Always map enry->bblfsh language names

### DIFF
--- a/daemon/language.go
+++ b/daemon/language.go
@@ -18,7 +18,7 @@ func GetLanguage(filename string, content []byte) string {
 }
 
 // normalize maps enry language names to the bblfsh ones.
-// TODO(bzz): remove this as soon as languafe_aliaces are supported in bblfsh
+// TODO(bzz): remove this as soon as language aliases are supported in bblfsh
 // driver manifest.
 func normalize(languageName string) string {
 	lang := strings.ToLower(languageName)

--- a/daemon/language.go
+++ b/daemon/language.go
@@ -14,7 +14,14 @@ func GetLanguage(filename string, content []byte) string {
 		return lang
 	}
 
-	lang = strings.ToLower(lang)
+	return normalize(lang)
+}
+
+// normalize maps enry language names to the bblfsh ones.
+// TODO(bzz): remove this as soon as languafe_aliaces are supported in bblfsh
+// driver manifest.
+func normalize(languageName string) string {
+	lang := strings.ToLower(languageName)
 	lang = strings.Replace(lang, " ", "-", -1)
 	lang = strings.Replace(lang, "+", "p", -1)
 	lang = strings.Replace(lang, "#", "sharp", -1)

--- a/daemon/service.go
+++ b/daemon/service.go
@@ -102,6 +102,8 @@ func (s *ServiceV2) selectPool(rctx context.Context, language, content, filename
 			return "", nil, err
 		}
 		language = lang
+	} else { // always re-map enry->bblfsh language names
+		language = normalize(language)
 	}
 
 	dp, err := s.daemon.DriverPool(ctx, language)
@@ -225,6 +227,8 @@ func (s *Service) selectPool(ctx context.Context, language, content, filename st
 			return language, nil, ErrLanguageDetection.New()
 		}
 		logrus.Debugf("detected language %q, filename %q", language, filename)
+	} else { // always re-map enry->bblfsh language names
+		language = normalize(language)
 	}
 
 	dp, err := s.daemon.DriverPool(ctx, language)


### PR DESCRIPTION
This fixes https://github.com/bblfsh/client-go/issues/108

Before, we were mapping enry->bblfsh language name only in case it was detected by bblfshd itself (by calling to enry).

Now same change is applied on any user input, as the main use case for the clients is to detect language with Enry first and then call bblfshd with it, but language names are different (e.g `C#` vs `csharp`)

This is a workaround, until proper multiple `language_aliaces` are supported by every driver in it's manifest.

TEST PLAN:
 -  `$ bblfsh-cli -l 'C#'./some.cs`