### PR TITLE
Fix the context passed to the driver factory

### DIFF
--- a/daemon/common_test.go
+++ b/daemon/common_test.go
@@ -26,7 +26,7 @@ type mockDriver struct {
 	MockStatus  protocol.Status
 }
 
-func newMockDriver() (Driver, error) {
+func newMockDriver(ctx context.Context) (Driver, error) {
 	return &mockDriver{
 		MockID:     runtime.NewULID().String(),
 		MockStatus: protocol.Running,
@@ -63,7 +63,7 @@ func (d *mockDriver) Stop() error {
 }
 
 func newEchoDriver() *echoDriver {
-	d, _ := newMockDriver()
+	d, _ := newMockDriver(context.Background())
 	return &echoDriver{
 		Driver: d,
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -173,11 +173,11 @@ func (d *Daemon) getDriverImage(rctx context.Context, language string) (runtime.
 
 // newDriverPool, instance a new driver pool for the given language and image
 // and should be called under a lock.
-func (d *Daemon) newDriverPool(rctx context.Context, language string, image runtime.DriverImage) (*DriverPool, error) {
-	sp, _ := opentracing.StartSpanFromContext(rctx, "bblfshd.pool.newDriverPool")
+func (d *Daemon) newDriverPool(ctx context.Context, language string, image runtime.DriverImage) (*DriverPool, error) {
+	sp, _ := opentracing.StartSpanFromContext(ctx, "bblfshd.pool.newDriverPool")
 	defer sp.Finish()
 
-	dp := NewDriverPool(func() (Driver, error) {
+	dp := NewDriverPool(func(ctx context.Context) (Driver, error) {
 		logrus.Debugf("spawning driver instance %q ...", image.Name())
 
 		opts := d.getDriverInstanceOptions()
@@ -186,7 +186,7 @@ func (d *Daemon) newDriverPool(rctx context.Context, language string, image runt
 			return nil, err
 		}
 
-		if err := driver.Start(rctx); err != nil {
+		if err := driver.Start(ctx); err != nil {
 			return nil, err
 		}
 
@@ -198,7 +198,7 @@ func (d *Daemon) newDriverPool(rctx context.Context, language string, image runt
 		"language": language,
 	})
 
-	if err := dp.Start(); err != nil {
+	if err := dp.Start(ctx); err != nil {
 		return nil, err
 	}
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -127,11 +127,11 @@ func buildMockedDaemon(t *testing.T, images ...runtime.DriverImage) (*Daemon, st
 	parsedBuild, err := time.Parse(time.RFC3339, testBuildDate)
 	d := NewDaemon("foo", parsedBuild, r)
 
-	dp := NewDriverPool(func() (Driver, error) {
+	dp := NewDriverPool(func(ctx context.Context) (Driver, error) {
 		return newEchoDriver(), nil
 	})
 
-	err = dp.Start()
+	err = dp.Start(context.Background())
 	require.NoError(err)
 
 	d.pool["python"] = dp


### PR DESCRIPTION
Previous changes added a context argument to newDriverPool, which is called when the first request for the driver is received. By mistake, the context of this first request is captured by the closure and is used to create all other driver instances. Thus, if the first request specifies the context timeout and fails for some reason, all future requests will fail with "context canceled" error.

Instead, we need to pass the real context from the user request down to the pool's driver factory function.

This is not an ideal way of managing drivers - pool should be managed by a separate goroutine. This will be implemented later. This is merely a hotfix for the real issue.

Fixes #253

Signed-off-by: Denys Smirnov <denys@sourced.tech>