### PR TITLE
Validate that source files are encoded in UTF-8

### DIFF
--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -21,4 +21,6 @@ var (
 	ErrUnauthorized = errors.NewKind("unauthorized: authentication required to access %s (image: %s)")
 	// ErrLanguageDetection indicates that language was not detected by Enry.
 	ErrLanguageDetection = errors.NewKind("could not autodetect language")
+	// ErrUnknownEncoding is returned for parse requests with a file content in a non-UTF8 encoding.
+	ErrUnknownEncoding = errors.NewKind("unknown source file encoding (expected UTF-8)")
 )


### PR DESCRIPTION
As described in #238, all the driver pipeline expects file content to be UTF-8, however, we do not strictly enforce it.

This change adds additional checks in `Parse` methods to ensure that content is encoded correctly.

Fixes #238

Signed-off-by: Denys Smirnov <denys@sourced.tech>