### PR TITLE
Rewrite driver pool

### DIFF
--- a/daemon/pool.go
+++ b/daemon/pool.go
@@ -655,6 +655,11 @@ func (dp *DriverPool) getDriver(rctx context.Context) (Driver, error) {
 	sp, ctx := opentracing.StartSpanFromContext(rctx, "bblfshd.pool.getDriver")
 	defer sp.Finish()
 
+	if dp.poolCtx == nil {
+		// not running
+		return nil, ErrPoolClosed.New()
+	}
+
 	for {
 		d, err := dp.getIdle(ctx)
 		if ErrPoolClosed.Is(err) {

--- a/daemon/pool_test.go
+++ b/daemon/pool_test.go
@@ -58,10 +58,14 @@ func TestDriverPoolExecute_Timeout(t *testing.T) {
 		return newMockDriver(ctx)
 	})
 
+	err := dp.Start(context.Background())
+	require.NoError(err)
+	defer dp.Stop()
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
 	defer cancel()
 
-	err := dp.ExecuteCtx(ctx, nil)
+	err = dp.ExecuteCtx(ctx, nil)
 	require.True(err == context.DeadlineExceeded)
 }
 


### PR DESCRIPTION
Based on #257. Only the last commit is relevant.

An old pool had some problems like leaking goroutines, leaving dead drivers to hang for too long and unpredictable scaling behavior.

The new driver pool introduced in this change should be safer and more predictable. It may also fix issues with the scaling that we discovered.

New implementation still runs a scaling goroutine that sets a target number of instances. But instead of directly applying this number by killing or starting instances, it delegates instance management to a separate goroutine.

This second goroutine also accepts requests for idle drivers. It listens on multiple event channels and it should be now clean from the code what decision it would make on each event.

Also, an old implementation was using a client's request context when starting new instances. In this implementation, a third goroutine is responsible for starting instances in the background.