### PR TITLE
Print meaningful message if no recommended drivers are available

### DIFF
--- a/cmd/bblfshctl/cmd/driver_install.go
+++ b/cmd/bblfshctl/cmd/driver_install.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -78,6 +79,8 @@ func recommendedDrivers() (map[string]string, error) {
 	list, err := getOfficialDrivers()
 	if err != nil {
 		return nil, err
+	} else if len(list) == 0 {
+		return nil, errors.New("official drivers list is empty; try updating bblfshd")
 	}
 	m := make(map[string]string, len(list))
 	for _, d := range list {
@@ -85,6 +88,9 @@ func recommendedDrivers() (map[string]string, error) {
 			continue
 		}
 		m[d.Language] = driverImage(d.Language)
+	}
+	if len(m) == 0 {
+		return nil, errors.New("recommended drivers list is empty; try updating bblfshd")
 	}
 	return m, nil
 }


### PR DESCRIPTION
There may be cases when `bblfshd` cannot find any suitable drivers to be installed. It may happen mainly when `bblfshd` uses an old SDK version, while drivers use a new one (see https://github.com/bblfsh/bblfshd/issues/281).

PR adds a meaningful error for this case instead of exiting with no error and doing nothing.

Signed-off-by: Denys Smirnov <denys@sourced.tech>