### PR TITLE
Recreate the control socket after a crash

### DIFF
--- a/cmd/bblfshd/main.go
+++ b/cmd/bblfshd/main.go
@@ -199,6 +199,13 @@ func listenUser(d *daemon.Daemon) {
 
 func listenControl(d *daemon.Daemon) {
 	var err error
+	if *ctl.network == "unix" {
+		// Remove returns an error if file does not exists
+		// if it returns nil, we know the file existed, so bblfshd might have crashed
+		if err := os.Remove(*ctl.address); err == nil {
+			logrus.Warningf("control socket %s (%s) already exists", *ctl.address, *ctl.network)
+		}
+	}
 	ctlListener, err = net.Listen(*ctl.network, *ctl.address)
 	if err != nil {
 		logrus.Fatalf("error creating control listener: %s", err)


### PR DESCRIPTION
As reported in #286, `bblfshd` will not be able to restart after a crash because of the following error:
```
error creating control listener: listen unix /var/run/bblfshctl.sock: bind: address already in use
```

This usually happens on OOM kill, when `bblfshd` has no chance to clean up the socket on shutdown.

This change checks for this specific error, tries to determine if the socket is in use, and if not - removes it and tries to listen on it again.

Signed-off-by: Denys Smirnov <denys@sourced.tech>