### PR TITLE
bblfshctl: Add an option to use v2 parsing protocol

### DIFF
--- a/cmd/bblfshctl/cmd/driver_list.go
+++ b/cmd/bblfshctl/cmd/driver_list.go
@@ -41,6 +41,15 @@ func (c *DriverListCommand) Execute(args []string) error {
 	return err
 }
 
+func printErrors(errors []string) {
+	if len(errors) != 0 {
+		fmt.Println("Errors:")
+		for _, err := range errors {
+			fmt.Printf("\t- %s\n", err)
+		}
+	}
+}
+
 func driverStatusToText(r *protocol.DriverStatesResponse) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Language", "Image", "Version", "Status", "Created", "Go", "Native"})

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/bblfsh/bblfshd
 
 require (
 	github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774 // indirect
+	github.com/bblfsh/go-client/v4 v4.0.1
 	github.com/bblfsh/sdk/v3 v3.0.0
 	github.com/beorn7/perks v1.0.0 // indirect
 	github.com/briandowns/spinner v0.0.0-20170614154858-48dbb65d7bd5
@@ -56,7 +57,7 @@ require (
 	golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6
 	golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872 // indirect
 	golang.org/x/text v0.3.2 // indirect
-	google.golang.org/grpc v1.13.0
+	google.golang.org/grpc v1.14.0
 	gopkg.in/bblfsh/sdk.v1 v1.16.1
 	gopkg.in/src-d/enry.v1 v1.6.1
 	gopkg.in/src-d/go-errors.v1 v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/antchfx/xpath v0.0.0-20180922041825-3de91f3991a1/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
+github.com/bblfsh/go-client/v4 v4.0.1 h1:1sM/mIchlw872S5jtT4BnPI+oo6eiNaP/B0QedDAchw=
+github.com/bblfsh/go-client/v4 v4.0.1/go.mod h1:Dxot07alCbqwIleIn1AQYiCDfolddYh1z1hhakZhUss=
 github.com/bblfsh/sdk/v3 v3.0.0 h1:bCyTC8gEcMSIo1wzuYpbMYKK9L1KFEzgrEckVvraELc=
 github.com/bblfsh/sdk/v3 v3.0.0/go.mod h1:juMiu8rP3lYJN1e4neEkSyzNieqiFceZzN4AOo0Rm1Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -232,8 +234,12 @@ golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/genproto v0.0.0-20180716172848-2731d4fa720b h1:mXqBiicV0B+k8wzFNkKeNBRL7LyRV5xG0s+S6ffLb/E=
 google.golang.org/genproto v0.0.0-20180716172848-2731d4fa720b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
+google.golang.org/genproto v0.0.0-20180731170733-daca94659cb5 h1:2PjFmwzH/sxgW9CRJDlEiwMHO8rOk1eMDzVL14HC1e4=
+google.golang.org/genproto v0.0.0-20180731170733-daca94659cb5/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.13.0 h1:bHIbVsCwmvbArgCJmLdgOdHFXlKqTOVjbibbS19cXHc=
 google.golang.org/grpc v1.13.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
+google.golang.org/grpc v1.14.0 h1:ArxJuB1NWfPY6r9Gp9gqwplT0Ge7nqv9msgu03lHLmo=
+google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 gopkg.in/airbrake/gobrake.v2 v2.0.9 h1:7z2uVWwn7oVeeugY1DtlPAy5H+KYgB1KeKTnqjNatLo=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=


### PR DESCRIPTION
Add a `--v2` CLI flag to `bblfshctl parse` to use the v2 parsing protocol.

The v1 can only be deprecated with a major version bump, so postpone the change for CLI until #210.

Resolves #285

Signed-off-by: Denys Smirnov <denys@sourced.tech>