### PR TITLE
Expose version to Prometheus

### DIFF
--- a/cmd/bblfshd/main.go
+++ b/cmd/bblfshd/main.go
@@ -17,23 +17,24 @@ import (
 	"github.com/bblfsh/bblfshd/daemon"
 	"github.com/bblfsh/bblfshd/runtime"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/sirupsen/logrus"
-	jaegercfg "github.com/uber/jaeger-client-go/config"
-
 	cmdutil "github.com/bblfsh/sdk/v3/cmd"
 	"github.com/bblfsh/sdk/v3/driver/manifest/discovery"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	pversion "github.com/prometheus/common/version"
+	"github.com/sirupsen/logrus"
+	jaegercfg "github.com/uber/jaeger-client-go/config"
 	"gopkg.in/bblfsh/sdk.v1/sdk/server"
 )
 
 const (
-	defaultBuild    = "undefined"
+	undefined       = "undefined"
 	buildDateFormat = "2006-01-02T15:04:05-0700"
 )
 
 var (
-	version = "undefined"
-	build   = defaultBuild
+	version = undefined
+	build   = undefined
 
 	network        *string
 	address        *string
@@ -64,6 +65,10 @@ var (
 )
 
 func init() {
+	pversion.Version = version
+	pversion.BuildDate = build
+	prometheus.MustRegister(pversion.NewCollector("bblfshd"))
+
 	cmd = flag.NewFlagSet("bblfshd", flag.ExitOnError)
 	network = cmd.String("network", "tcp", "network type: tcp, tcp4, tcp6, unix or unixpacket.")
 	address = cmd.String("address", "0.0.0.0:9432", "address to listen.")
@@ -152,7 +157,7 @@ func main() {
 
 	parsedBuild, err := time.Parse(buildDateFormat, build)
 	if err != nil {
-		if build == defaultBuild {
+		if build == undefined {
 			parsedBuild = time.Now()
 			logrus.Infof("using start time instead in this dev build: %s",
 				parsedBuild.Format(buildDateFormat))


### PR DESCRIPTION
Expose the `bblfshd` version to Prometheus, so we can see when the migration to a new version happens in our deployments.

Signed-off-by: Denys Smirnov <denis.smirnov.91@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/bblfshd/295)
<!-- Reviewable:end -->
