### PR TITLE
Avoid 'transport closing' errors on client side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+bblfshd
+bblfshctl

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -9,9 +9,11 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+
 	"github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
 
 	"github.com/bblfsh/bblfshd/daemon/protocol"
 	"github.com/bblfsh/bblfshd/runtime"
@@ -19,6 +21,18 @@ import (
 	"github.com/bblfsh/sdk/v3/driver/manifest"
 	protocol2 "github.com/bblfsh/sdk/v3/protocol"
 	protocol1 "gopkg.in/bblfsh/sdk.v1/protocol"
+)
+
+const (
+	// keepaliveMinTime is the minimum amount of time a client should wait before sending
+	// a keepalive ping.
+	keepaliveMinTime = 1 * time.Minute
+
+	// keepalivePingWithoutStream is a boolean flag.
+	// If true, server allows keepalive pings even when there are no active
+	// streams(RPCs). If false, and client sends ping when there are no active
+	// streams, server will send GOAWAY and close the connection.
+	keepalivePingWithoutStream = true
 )
 
 // Daemon is a Babelfish server.
@@ -38,8 +52,16 @@ type Daemon struct {
 
 // NewDaemon creates a new server based on the runtime with the given version.
 func NewDaemon(version string, build time.Time, r *runtime.Runtime, opts ...grpc.ServerOption) *Daemon {
-	commonOpt := protocol2.ServerOptions()
-	opts = append(opts, commonOpt...)
+	commonOpt := append(protocol2.ServerOptions(),
+		// EnforcementPolicy is used to set keepalive enforcement policy on the
+		// server-side. Server will close connection with a client that violates this
+		// policy.
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             keepaliveMinTime,
+			PermitWithoutStream: keepalivePingWithoutStream,
+		}),
+	)
+	opts = append(commonOpt, opts...)
 
 	d := &Daemon{
 		version:       version,

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
-	github.com/prometheus/common v0.3.0 // indirect
+	github.com/prometheus/common v0.3.0
 	github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0 // indirect
 	github.com/seccomp/libseccomp-golang v0.0.0-20170625204121-f6ec81daf48e // indirect
 	github.com/sirupsen/logrus v1.4.2


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>
Addresses: https://github.com/bblfsh/go-client/issues/124
https://github.com/bblfsh/go-client/issues/124#issuecomment-506055327

This PR sets `grpc.KeepaliveEnforcementPolicy` to common server options, by decreasing `MinTime` from 5 to 1 minute and setting `PermitWithoutStream` to `true`.

EnforcementPolicy is used to set keepalive enforcement policy on the
server-side. Server will close connection with a client that violates this policy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/bblfshd/299)
<!-- Reviewable:end -->
