### PR TITLE
Kill driver on parse ctx.Done

### DIFF
--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -39,6 +39,7 @@ var (
 )
 
 // Public API metrics
+// TODO(dennwc): add parse timeout metric
 var (
 	parseCalls = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "bblfshd_parse_total",

--- a/daemon/service_test.go
+++ b/daemon/service_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -18,9 +19,37 @@ func TestServiceParse(t *testing.T) {
 	s := NewService(d)
 	resp := s.Parse(&protocol.ParseRequest{Filename: "foo.py", Content: "foo"})
 	require.Len(resp.Errors, 0)
-	require.Equal(resp.UAST.Token, "foo")
-	require.Equal(resp.Language, "python")
+	require.Equal("foo", resp.UAST.Token)
+	require.Equal("python", resp.Language)
 	require.True(resp.Elapsed.Nanoseconds() > 0)
+}
+
+// TODO(dennwc): Add test cases for V2
+func TestServiceParseV1(t *testing.T) {
+	require := require.New(t)
+
+	d, tmp := buildMockedDaemon(t)
+	defer os.RemoveAll(tmp)
+
+	s := NewService(d)
+	req := &protocol.ParseRequest{Filename: "foo.py", Content: "foo"}
+	lang, dp, err := s.selectPool(context.TODO(), req.Language, req.Content, req.Filename)
+	require.NoError(err)
+	require.Equal("python", lang)
+
+	resp := &protocol.ParseResponse{}
+	err = dp.Execute(func(ctx context.Context, driver Driver) error {
+		ctx, cancel := context.WithCancel(ctx)
+		cancel() // simulate context.Done
+
+		// because we have a parseKillDelay ultimately we'll get response without errors
+		resp, err = parseV1(ctx, dp, driver, req)
+		return err
+	}, req.Timeout)
+
+	require.NoError(err)
+	require.Len(resp.Errors, 0)
+	require.Equal("foo", resp.UAST.Token)
 }
 
 func TestServiceNativeParse(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>
This PR partly fixes #297 (on the daemon side). The next step is to try restart a native driver (internally), so it should be done on sdk side.
We may also think about exposing _parse timeout_ flag for bblfshd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/bblfshd/306)
<!-- Reviewable:end -->
