### PR TITLE
docker image cron update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,15 @@ before_install:
   - popd
   - make dependencies
 
+# there's a workaround here because there will be no tags in cron https://github.com/travis-ci/travis-ci/issues/8146
 script:
   - make test-coverage
+  - |
+    if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
+      if CRON_TAG="$( git describe --exact-match "$(git rev-parse HEAD)" 2>/dev/null )"; then
+        make push-drivers
+      fi
+    fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This PR contains changes to travis and Makefile configs for periodical docker image update using travis ci cron jobs

Behavior
1) if TRAVIS_EVENT_TYPE is cron then
  a) try to get tag using `$( git describe --exact-match "$(git rev-parse HEAD)`
  b) if tag is not empty run make push-drivers
  c) in push-drivers: if TRAVIS_EVENT_TYPE is cron pull base bblfshd image instead of rebuilding it from the scratch
2) else build as always

Changes to docker tags:
- timestamp is added to the version tag, so the final image will look like `bblfsh/bblfshd:v2.14.0-drivers-2019-10-04`

Problems:
- afaik deploy will not be triggered on cron job because tags are not accessible with this event type https://github.com/travis-ci/travis-ci/issues/8146 ... cannot check it on practice thus 1.a) workaround has been implemented as suggested https://github.com/travis-ci/travis-ci/issues/8146#issuecomment-439617546

closes #309

Signed-off-by: lwsanty <lwsanty@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/bblfshd/314)
<!-- Reviewable:end -->
