### PR TITLE
fix cron tag condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - make test-coverage
   - |
     if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
-      if CRON_TAG="$( git describe --exact-match "$(git rev-parse HEAD)" 2>/dev/null )"; then
+      if CRON_TAG="$( git describe --exact-match "$(git rev-parse HEAD)" --tags 2>/dev/null )"; then
         make push-drivers
       fi
     fi


### PR DESCRIPTION
as was figured out on practice, our tags are unannotated, thus require `--tags`

Signed-off-by: lwsanty <lwsanty@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/bblfshd/315)
<!-- Reviewable:end -->
