### PR TITLE
Print content hashes in logs

### DIFF
--- a/daemon/service.go
+++ b/daemon/service.go
@@ -4,8 +4,12 @@ package daemon
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
+	"strconv"
 	"time"
 	"unicode/utf8"
 
@@ -29,6 +33,21 @@ var (
 	parseKillDelay = time.Second
 )
 
+func hashSHA1(content string) string {
+	h := sha1.New()
+	io.WriteString(h, content)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func hashGit(content string) string {
+	h := sha1.New()
+	io.WriteString(h, "blob ")
+	io.WriteString(h, strconv.Itoa(len(content)))
+	io.WriteString(h, "\x00")
+	io.WriteString(h, content)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
 type ServiceV2 struct {
 	daemon *Daemon
 }
@@ -49,7 +68,7 @@ func (s *ServiceV2) Parse(rctx xcontext.Context, req *protocol2.ParseRequest) (r
 	resp = &protocol2.ParseResponse{}
 	start := time.Now()
 	defer func() {
-		s.logResponse(gerr, req.Filename, req.Language, len(req.Content), time.Since(start))
+		s.logResponse(gerr, req.Filename, req.Language, req.Content, time.Since(start))
 	}()
 
 	if req.Content == "" {
@@ -141,7 +160,7 @@ func (s *ServiceV2) SupportedLanguages(rctx xcontext.Context, _ *protocol2.Suppo
 
 	start := time.Now()
 	defer func() {
-		s.logResponse(gerr, "", "", 0, time.Since(start))
+		s.logResponse(gerr, "", "", "", time.Since(start))
 	}()
 
 	drivers, err := s.daemon.runtime.ListDrivers()
@@ -159,7 +178,7 @@ func (s *ServiceV2) SupportedLanguages(rctx xcontext.Context, _ *protocol2.Suppo
 	return &protocol2.SupportedLanguagesResponse{Languages: out}, nil
 }
 
-func (s *ServiceV2) logResponse(err error, filename string, language string, size int, elapsed time.Duration) {
+func (s *ServiceV2) logResponse(err error, filename, language, content string, elapsed time.Duration) {
 	fields := log.Fields{"elapsed": elapsed}
 	if filename != "" {
 		fields["filename"] = filename
@@ -169,8 +188,13 @@ func (s *ServiceV2) logResponse(err error, filename string, language string, siz
 		fields["language"] = language
 	}
 
+	if content != "" {
+		fields["sha1"] = hashSHA1(content)
+		fields["githash"] = hashGit(content)
+	}
+
 	l := log.With(fields)
-	text := fmt.Sprintf("request processed content %d bytes", size)
+	text := fmt.Sprintf("request processed content %d bytes", len(content))
 
 	if err != nil {
 		l.Errorf(err, "%s", text)
@@ -237,7 +261,7 @@ func (d *Service) Parse(req *protocol1.ParseRequest) *protocol1.ParseResponse {
 		dt := time.Since(start)
 		parseLatencyV1.Observe(dt.Seconds())
 		resp.Elapsed = dt
-		d.logResponse(resp.Status, req.Filename, req.Language, len(req.Content), resp.Elapsed)
+		d.logResponse(resp.Status, req.Filename, req.Language, req.Content, resp.Elapsed)
 	}()
 
 	if req.Content == "" {
@@ -307,7 +331,7 @@ func parseV1(ctx context.Context, pool *DriverPool, drv Driver, req *protocol1.P
 	}
 }
 
-func (d *Service) logResponse(s protocol1.Status, filename string, language string, size int, elapsed time.Duration) {
+func (d *Service) logResponse(s protocol1.Status, filename, language, content string, elapsed time.Duration) {
 	fields := log.Fields{"elapsed": elapsed}
 	if filename != "" {
 		fields["filename"] = filename
@@ -317,8 +341,13 @@ func (d *Service) logResponse(s protocol1.Status, filename string, language stri
 		fields["language"] = language
 	}
 
+	if content != "" {
+		fields["sha1"] = hashSHA1(content)
+		fields["githash"] = hashGit(content)
+	}
+
 	l := log.With(fields)
-	text := fmt.Sprintf("request processed content %d bytes, status %s", size, s)
+	text := fmt.Sprintf("request processed content %d bytes, status %s", len(content), s)
 
 	switch s {
 	case protocol1.Ok:
@@ -344,7 +373,7 @@ func (d *Service) NativeParse(req *protocol1.NativeParseRequest) *protocol1.Nati
 		dt := time.Since(start)
 		parseLatencyV1.Observe(dt.Seconds())
 		resp.Elapsed = dt
-		d.logResponse(resp.Status, req.Language, req.Language, len(req.Content), resp.Elapsed)
+		d.logResponse(resp.Status, req.Language, req.Language, req.Content, resp.Elapsed)
 	}()
 
 	if req.Content == "" {
@@ -409,7 +438,7 @@ func (d *Service) Version(req *protocol1.VersionRequest) *protocol1.VersionRespo
 	start := time.Now()
 	defer func() {
 		resp.Elapsed = time.Since(start)
-		d.logResponse(resp.Status, "", "", 0, resp.Elapsed)
+		d.logResponse(resp.Status, "", "", "", resp.Elapsed)
 	}()
 	return resp
 }
@@ -446,7 +475,7 @@ func (d *Service) SupportedLanguages(req *protocol1.SupportedLanguagesRequest) *
 	start := time.Now()
 	defer func() {
 		resp.Elapsed = time.Since(start)
-		d.logResponse(resp.Status, "", "", 0, resp.Elapsed)
+		d.logResponse(resp.Status, "", "", "", resp.Elapsed)
 	}()
 
 	drivers, err := d.daemon.runtime.ListDrivers()

--- a/daemon/service_test.go
+++ b/daemon/service_test.go
@@ -10,6 +10,12 @@ import (
 	"gopkg.in/bblfsh/sdk.v1/protocol"
 )
 
+func TestHash(t *testing.T) {
+	const data = "abc\n"
+	require.Equal(t, "03cfd743661f07975fa2f1220c5194cbaff48451", hashSHA1(data))
+	require.Equal(t, "8baef1b4abc478178b004d62031cf7fe6db6f903", hashGit(data))
+}
+
 func TestServiceParse(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
Tracking down bugs in driver is hard if all we get in logs is the filename. To help with it, also log the file content.

The proposal is to log both SHA1 and Git hash. The reason is outlined in https://github.com/bblfsh/bblfshd/issues/302, but in short, we want to be able to search Git itself for the file using the Git hash, and also see the original file hash (as reported by `sha1sum`) in case files are not originating from Git (e.g. sent from CLI or the client).

The open question is, do we want SHA1 specifically (apart from a Git hash)?

MD5 might be much faster, but may result in collisions. At the same time, it's returned as a metadata field in cloud storage services provided by Google and AWS.

If not MD5, Blake2 may be a good alternative both in terms of performance and avoiding collisions. The downside is, of course, that it's not used as widely as SHA1.

Resolves #302

Signed-off-by: Denys Smirnov <denys@sourced.tech>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/bblfshd/324)
<!-- Reviewable:end -->
