### PR TITLE
Set log level to "info" for Parse requests

### DIFF
--- a/daemon/service.go
+++ b/daemon/service.go
@@ -199,7 +199,7 @@ func (s *ServiceV2) logResponse(err error, filename, language, content string, e
 	if err != nil {
 		l.Errorf(err, "%s", text)
 	} else {
-		l.Debugf("%s", text)
+		l.Infof("%s", text)
 	}
 }
 
@@ -351,7 +351,7 @@ func (d *Service) logResponse(s protocol1.Status, filename, language, content st
 
 	switch s {
 	case protocol1.Ok:
-		l.Debugf("%s", text)
+		l.Infof("%s", text)
 	case protocol1.Error:
 		l.Warningf("%s", text)
 	case protocol1.Fatal:


### PR DESCRIPTION
Currently, the log level for Parse requests is set to `debug`. I think it makes sense to increase it to `info` because it's the main request type that server processes.

Signed-off-by: Denys Smirnov <denys@sourced.tech>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/bblfshd/328)
<!-- Reviewable:end -->
